### PR TITLE
Rename JAVA package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@
 .atom/
 .buildlog/
 .history
+.project
 .svn/
+bin/
 
 # IntelliJ related
 *.iml

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.baseflow.flutter">
+  package="com.baseflow.flutter.plugin.geolocator">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/GeolocatorPlugin.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/GeolocatorPlugin.java
@@ -1,4 +1,4 @@
-package com.baseflow.flutter;
+package com.baseflow.flutter.plugin.geolocator;
 
 import android.Manifest;
 import android.content.IntentSender;

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/LocationMapper.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/LocationMapper.java
@@ -1,4 +1,4 @@
-package com.baseflow.flutter;
+package com.baseflow.flutter.plugin.geolocator;
 
 import android.location.Location;
 import android.os.Build;

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.baseflow.fluttergeolocatorexample">
+    package="com.baseflow.flutter.plugin.geolocator.example">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application

--- a/example/android/app/src/main/java/com/baseflow/flutter/plugin/geolocator/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/baseflow/flutter/plugin/geolocator/example/MainActivity.java
@@ -1,4 +1,4 @@
-package com.baseflow.fluttergeolocatorexample;
+package com.baseflow.flutter.plugin.geolocator.example;
 
 import android.os.Bundle;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
 # The following section is specific to Flutter.
 flutter:
   plugin:
-    androidPackage: com.baseflow.flutter
+    androidPackage: com.baseflow.flutter.plugin.geolocator
     pluginClass: GeolocatorPlugin
 
   # To add assets to your plugin package, add an assets section, like this:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Java package had invalid name (`com.baseflow.flutter`)

### :new: What is the new behavior (if this is a feature change)?

Renamed to the correct identifier `com.baseflow.flutter.plugin.geolocator`

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run unit-tests: `flutter test`

### :memo: Links to relevant issues/docs

See slack discussion in #flutter channel

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Rebased onto current develop