### PR TITLE
Make sure state is cleaned up correctly

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,4 +66,14 @@ class _MyAppState extends State<MyApp> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    if(_positionSubscription != null) {
+      _positionSubscription.cancel();
+      _positionSubscription = null;
+    }
+
+    super.dispose();
+  }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The flutter analyser complains about two issues in the example app:
1. The value of the field '_positionSubscription' isn't used.
2. Cancel instances of `dart.async.StreamSubscription`.

### :new: What is the new behavior (if this is a feature change)?

This PR solves both problems by using the field `_positionSubscription` to cancel the `StreamSubscription` when the state is being disposed.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example in a simulator

### :memo: Links to relevant issues/docs

- [dispose method](https://docs.flutter.io/flutter/widgets/State/dispose.html)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Rebased onto current develop
