### PR TITLE
Support configuration of distance filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,21 @@ import 'package:geolocator/geolocator.dart';
 import 'package:geolocator/models/location_accuracy.dart';
 import 'package:geolocator/models/position.dart';
 
-Position position = await new Geolocator().getPosition(LocationAccuracy.High);
+Position position = await Geolocator().getPosition(LocationAccuracy.High);
 ```
 
-To listen for location changes you can subscribe to the `onPositionChanged` stream:
+To listen for location changes you can subscribe to the `onPositionChanged` stream. Supply an instance of the `LocationOptions` class to configure
+the desired accuracy and the minimum distance change (in meters) before updates are send to the application.
 
 ``` dart
 import 'package:geolocator/geolocator.dart';
 import 'package:geolocator/models/location_accuracy.dart';
 import 'package:geolocator/models/position.dart';
 
-Geolocator geolocator = new Geolocator();
-StreamSubscription<Position> positionStream = geolocator.getPositionStream(LocationAccuracy.High).listen(
+var geolocator = Geolocator();
+var locationOptions = LocationOptions(accuracy: LocationAccuracy.High, distanceFilter: 10);
+
+StreamSubscription<Position> positionStream = geolocator.getPositionStream(locationOptions).listen(
     (Position position) {
         print(_position == null ? 'Unknown' : _position.latitude.toString() + ', ' + _position.longitude.toString());
     });
@@ -60,7 +63,7 @@ To translate an address into latitude and longitude coordinates you can use the 
 import 'package:geolocator/geolocator.dart';
 import 'package:geolocator/models/placemark.dart';
 
-Placemark placemark = await new Geolocator().toPlacemark("Gronausestraat 710, Enschede");
+Placemark placemark = await Geolocator().toPlacemark("Gronausestraat 710, Enschede");
 ```
 
 If you want to translate latitude and longitude coordinates into an address you can use the `fromPlacemark` method:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,4 +38,5 @@ android {
 dependencies {
     api 'com.android.support:support-v4:27.1.0'
     api 'com.google.android.gms:play-services-location:15.+'
+    implementation 'com.google.code.gson:gson:2.8.5'
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/Codec.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/Codec.java
@@ -1,0 +1,13 @@
+package com.baseflow.flutter.plugin.geolocator;
+
+import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
+
+import com.google.gson.Gson;
+
+public class Codec {
+    private static final Gson GSON_DECODER = new Gson();
+
+    public static LocationOptions decodeLocationOptions(Object arguments) {
+        return GSON_DECODER.fromJson((String)arguments, LocationOptions.class);
+    }
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeolocationAccuracy.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeolocationAccuracy.java
@@ -1,5 +1,16 @@
 package com.baseflow.flutter.plugin.geolocator.data;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum GeolocationAccuracy {
-    Lowest, Low, Medium, High, Best
+    @SerializedName("lowest")
+    Lowest,
+    @SerializedName("low")
+    Low,
+    @SerializedName("medium")
+    Medium,
+    @SerializedName("high")
+    High,
+    @SerializedName("best")
+    Best
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationOptions.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationOptions.java
@@ -1,0 +1,6 @@
+package com.baseflow.flutter.plugin.geolocator.data;
+
+public class LocationOptions {
+    public GeolocationAccuracy accuracy = GeolocationAccuracy.Best;
+    public long distanceFilter = 0;
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationTask.java
@@ -9,7 +9,9 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.support.v4.app.ActivityCompat;
 
+import com.baseflow.flutter.plugin.geolocator.Codec;
 import com.baseflow.flutter.plugin.geolocator.data.GeolocationAccuracy;
+import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 import com.google.android.gms.common.util.Strings;
 
 import java.util.List;
@@ -21,7 +23,7 @@ abstract class LocationTask extends Task {
     private static final long TWO_MINUTES = 120000;
 
     private final Activity mActivity;
-    GeolocationAccuracy mAccuracy;
+    protected final LocationOptions mLocationOptions;
 
     LocationTask(TaskContext context) {
         super(context);
@@ -33,24 +35,7 @@ abstract class LocationTask extends Task {
         PluginRegistry.RequestPermissionsResultListener permissionsResultListener = createPermissionsResultListener();
         registrar.addRequestPermissionsResultListener(permissionsResultListener);
 
-        mAccuracy = parseAccuracy(context.getArguments());
-    }
-
-    private static GeolocationAccuracy parseAccuracy(Object arguments) {
-        GeolocationAccuracy accuracy = GeolocationAccuracy.Medium;
-
-        if(arguments == null) return accuracy;
-
-        try {
-            int index = (Integer) arguments;
-            if(index > 0 && index < GeolocationAccuracy.values().length) {
-                accuracy = GeolocationAccuracy.values()[index];
-            }
-
-            return accuracy;
-        } catch(Exception ex) {
-            return GeolocationAccuracy.Medium;
-        }
+        mLocationOptions = Codec.decodeLocationOptions(context.getArguments());
     }
 
     protected abstract void acquirePosition();

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/StreamLocationTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/StreamLocationTask.java
@@ -28,7 +28,9 @@ public class StreamLocationTask extends LocationTask {
         }
 
         // Try to get the best possible location provider for the requested accuracy
-        String bestProvider = getBestProvider(locationManager, mAccuracy);
+        String bestProvider = getBestProvider(
+                locationManager,
+                mLocationOptions.accuracy);
 
         if(Strings.isEmptyOrWhitespace(bestProvider)) {
             handleError(
@@ -40,7 +42,7 @@ public class StreamLocationTask extends LocationTask {
 
         mLocationListener = new StreamLocationListener(
                 locationManager,
-                mAccuracy,
+                mLocationOptions.accuracy,
                 bestProvider);
 
         Looper looper = Looper.myLooper();
@@ -51,7 +53,7 @@ public class StreamLocationTask extends LocationTask {
         locationManager.requestLocationUpdates(
                 bestProvider,
                 0,
-                0,
+                mLocationOptions.distanceFilter,
                 mLocationListener,
                 looper);
     }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -240,7 +240,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
+				"${PODS_ROOT}/../.symlinks/flutter/ios-release/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/geolocator/geolocator.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:geolocator/models/location_accuracy.dart';
+import 'package:geolocator/models/location_options.dart';
 import 'package:geolocator/models/placemark.dart';
 import 'package:geolocator/models/position.dart';
 
@@ -30,7 +31,8 @@ class _MyAppState extends State<MyApp> {
     initPlatformState();
 
     _positionSubscription = _geolocator
-        .getPositionStream(LocationAccuracy.high)
+        .getPositionStream(LocationOptions(
+            accuracy: LocationAccuracy.high, distanceFilter: 10))
         .listen((Position position) {
       setState(() {
         _position = position;

--- a/ios/Classes/Codec.swift
+++ b/ios/Classes/Codec.swift
@@ -1,0 +1,16 @@
+//
+//  Codec.swift
+//  geolocator
+//
+//  Created by Maurits van Beusekom on 11/07/2018.
+//
+
+import Foundation
+
+struct Codec {
+    private static let jsonDecoder = JSONDecoder()
+    
+    static func decodeLocationOptions(from arguments: Any?) -> LocationOptions {
+        return try! jsonDecoder.decode(LocationOptions.self, from: (arguments as! String).data(using: .utf8)!)
+    }
+}

--- a/ios/Classes/Data/LocationOptions.swift
+++ b/ios/Classes/Data/LocationOptions.swift
@@ -1,0 +1,42 @@
+//
+//  LocationOptions.swift
+//  geolocator
+//
+//  Created by Maurits van Beusekom on 11/07/2018.
+//
+
+import Foundation
+import CoreLocation
+
+struct LocationOptions : Codable {
+    init() {
+        self.accuracy = GeolocationAccuracy.best
+        self.distanceFilter = 0
+    }
+    
+    var accuracy: GeolocationAccuracy
+    var distanceFilter: CLLocationDistance
+}
+
+enum GeolocationAccuracy : String, Codable {
+    case lowest = "lowest"
+    case low = "low"
+    case medium = "medium"
+    case high = "high"
+    case best = "best"
+    
+    var clValue: CLLocationAccuracy {
+        switch self {
+        case .lowest:
+            return kCLLocationAccuracyThreeKilometers
+        case .low:
+            return kCLLocationAccuracyKilometer
+        case .medium:
+            return kCLLocationAccuracyHundredMeters
+        case .high:
+            return kCLLocationAccuracyNearestTenMeters
+        case .best:
+            return kCLLocationAccuracyBest
+        }
+    }
+}

--- a/ios/Classes/SwiftGeolocatorPlugin.swift
+++ b/ios/Classes/SwiftGeolocatorPlugin.swift
@@ -2,10 +2,6 @@ import Flutter
 import UIKit
 import CoreLocation
 
-enum GeolocationAccuracy : Int {
-    case Lowest = 0, Low, Medium, High, Best
-}
-
 public class SwiftGeolocatorPlugin: NSObject, FlutterStreamHandler, FlutterPlugin, CLLocationManagerDelegate {
     private static let METHOD_CHANNEL_NAME = "flutter.baseflow.com/geolocator/methods"
     private static let EVENT_CHANNEL_NAME = "flutter.baseflow.com/geolocator/events"

--- a/ios/Classes/Tasks/LocationTask.swift
+++ b/ios/Classes/Tasks/LocationTask.swift
@@ -10,7 +10,7 @@ import Flutter
 import Foundation
 
 class LocationTask : NSObject, TaskProtocol, CLLocationManagerDelegate {
-    private var _desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyBest
+    private var _locationOptions: LocationOptions
     private var _locationManager: CLLocationManager?
     
     required init(
@@ -20,10 +20,9 @@ class LocationTask : NSObject, TaskProtocol, CLLocationManagerDelegate {
         self.taskID = UUID.init()
         self.context = context
         self.completionHandler = completionHandler
+        self._locationOptions = Codec.decodeLocationOptions(from: context.arguments)
         
         super.init()
-        
-        _desiredAccuracy = parseAccuracy(accuracy: context.arguments)
     }
     
     let taskID: UUID
@@ -49,7 +48,8 @@ class LocationTask : NSObject, TaskProtocol, CLLocationManagerDelegate {
                 
             }
             
-            _locationManager!.desiredAccuracy = _desiredAccuracy;
+            _locationManager!.desiredAccuracy = _locationOptions.accuracy.clValue;
+            _locationManager!.distanceFilter = _locationOptions.distanceFilter;
         }
         
         _locationManager!.startUpdatingLocation()
@@ -62,20 +62,6 @@ class LocationTask : NSObject, TaskProtocol, CLLocationManagerDelegate {
         
         guard let action = completionHandler else { return }
         action(taskID)
-    }
-    
-    private func parseAccuracy(accuracy: Any?) -> CLLocationAccuracy {
-        if let argument = accuracy as? Int, let accuracy = GeolocationAccuracy(rawValue: argument) {
-            switch(accuracy) {
-                case .Lowest: return kCLLocationAccuracyThreeKilometers
-                case .Low: return kCLLocationAccuracyKilometer
-                case .Medium: return kCLLocationAccuracyHundredMeters
-                case .High: return kCLLocationAccuracyNearestTenMeters
-                case .Best: return kCLLocationAccuracyBest
-            }
-        } else {
-            return kCLLocationAccuracyBest
-        }
     }
 }
 

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -2,10 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:geolocator/models/location_accuracy.dart';
+import 'package:geolocator/models/location_options.dart';
 import 'package:geolocator/models/placemark.dart';
 import 'package:meta/meta.dart';
 
 import 'models/position.dart';
+
+import 'utils/codec.dart';
 
 /// Provides easy access to the platform specific location services (CLLocationManager on iOS and FusedLocationProviderClient on Android)
 class Geolocator {
@@ -35,9 +38,42 @@ class Geolocator {
   /// When the [desiredAccuracy] is not supplied, it defaults to best.
   Future<Position> getPosition(
       [LocationAccuracy desiredAccuracy = LocationAccuracy.best]) async {
+    var locationOptions =
+        LocationOptions(accuracy: desiredAccuracy, distanceFilter: 0);
     var position =
-        await _methodChannel.invokeMethod('getPosition', desiredAccuracy.index);
+        await _methodChannel.invokeMethod('getPosition', locationOptions);
     return Position.fromMap(position);
+  }
+
+  /// Fires whenever the location changes outside the bounds of the [desiredAccuracy].
+  ///
+  /// This event starts all location sensors on the device and will keep them
+  /// active until you cancel listening to the stream or when the application
+  /// is killed.
+  ///
+  /// ```
+  /// StreamSubscription<Position> positionStream = new Geolocator().GetPostionStream().listen(
+  ///   (Position position) => {
+  ///     // Handle position changes
+  ///   });
+  ///
+  /// // When no longer needed cancel the subscription
+  /// positionStream.cancel();
+  /// ```
+  ///
+  /// You can customize the behaviour of the location updates by supplying an
+  /// instance [LocationOptions] class. When you don't supply any specific
+  /// options, default values will be used for each setting.
+  Stream<Position> getPositionStream(
+      [LocationOptions locationOptions = const LocationOptions()]) {
+    if (_onPositionChanged == null) {
+      _onPositionChanged = _eventChannel
+          .receiveBroadcastStream(Codec.encodeLocationOptions(locationOptions))
+          .map<Position>(
+              (element) => Position.fromMap(element.cast<String, double>()));
+    }
+
+    return _onPositionChanged;
   }
 
   /// Returns a list of [Placemark] instances found for the supplied address.
@@ -60,34 +96,5 @@ class Geolocator {
     var placemarks = await _methodChannel.invokeMethod('fromPlacemark',
         <String, double>{"latitude": latitude, "longitude": longitude});
     return Placemark.fromMaps(placemarks);
-  }
-
-  /// Fires whenever the location changes outside the bounds of the [desiredAccuracy].
-  ///
-  /// This event starts all location sensors on the device and will keep them
-  /// active until you cancel listening to the stream or when the application
-  /// is killed.
-  ///
-  /// ```
-  /// StreamSubscription<Position> positionStream = new Geolocator().GetPostionStream().listen(
-  ///   (Position position) => {
-  ///     // Handle position changes
-  ///   });
-  ///
-  /// // When no longer needed cancel the subscription
-  /// positionStream.cancel();
-  /// ```
-  ///
-  /// When the [desiredAccuracy] is not supplied, it defaults to best.
-  Stream<Position> getPositionStream(
-      [LocationAccuracy desiredAccuracy = LocationAccuracy.best]) {
-    if (_onPositionChanged == null) {
-      _onPositionChanged = _eventChannel
-          .receiveBroadcastStream(desiredAccuracy.index)
-          .map<Position>(
-              (element) => Position.fromMap(element.cast<String, double>()));
-    }
-
-    return _onPositionChanged;
   }
 }

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -41,7 +41,7 @@ class Geolocator {
     var locationOptions =
         LocationOptions(accuracy: desiredAccuracy, distanceFilter: 0);
     var position =
-        await _methodChannel.invokeMethod('getPosition', locationOptions);
+        await _methodChannel.invokeMethod('getPosition', Codec.encodeLocationOptions(locationOptions));
     return Position.fromMap(position);
   }
 

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -40,8 +40,8 @@ class Geolocator {
       [LocationAccuracy desiredAccuracy = LocationAccuracy.best]) async {
     var locationOptions =
         LocationOptions(accuracy: desiredAccuracy, distanceFilter: 0);
-    var position =
-        await _methodChannel.invokeMethod('getPosition', Codec.encodeLocationOptions(locationOptions));
+    var position = await _methodChannel.invokeMethod(
+        'getPosition', Codec.encodeLocationOptions(locationOptions));
     return Position.fromMap(position);
   }
 

--- a/lib/models/location_options.dart
+++ b/lib/models/location_options.dart
@@ -1,0 +1,20 @@
+import 'package:geolocator/models/location_accuracy.dart';
+
+/// Represents different options to configure the quality and frequency
+/// of location updates.
+class LocationOptions {
+  const LocationOptions({
+    this.accuracy = LocationAccuracy.best,
+    this.distanceFilter = 0,
+  });
+
+  /// Defines the desired accuracy that should be used to determine the location data.
+  ///
+  /// The default value for this field is [LocationAccuracy.best].
+  final LocationAccuracy accuracy;
+
+  /// The minimum distance (measured in meters) a device must move horizontally before an update event is generated.
+  ///
+  /// Supply 0 when you want to be notified of all movements. The default is 0.
+  final int distanceFilter;
+}

--- a/lib/utils/codec.dart
+++ b/lib/utils/codec.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+
+import 'package:geolocator/models/location_options.dart';
+
+class Codec {
+  static String encodeLocationOptions(LocationOptions locationOptions) =>
+      json.encode(_locationOptionsMap(locationOptions));
+
+  static String encodeEnum(dynamic value) {
+    return value.toString().split('.').last;
+  }
+
+  static Map<String, dynamic> _locationOptionsMap(
+          LocationOptions locationOptions) =>
+      {
+        "accuracy": Codec.encodeEnum(locationOptions.accuracy),
+        "distanceFilter": locationOptions.distanceFilter
+      };
+}

--- a/test/geolocator_test.dart
+++ b/test/geolocator_test.dart
@@ -4,6 +4,7 @@ import 'package:async/async.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/models/location_accuracy.dart';
 import 'package:geolocator/models/location_options.dart';
+import 'package:geolocator/utils/codec.dart';
 import 'package:mockito/mockito.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:geolocator/models/position.dart';
@@ -79,11 +80,12 @@ void main() {
   });
 
   test('Retrieve the current position', () async {
+    var codedOptions = Codec.encodeLocationOptions(LocationOptions(accuracy: LocationAccuracy.best, distanceFilter: 0));
     when(_methodChannel.invokeMethod(
-            'getPosition', LocationAccuracy.best.index))
+            'getPosition', codedOptions))
         .thenAnswer((_) async => _mockPosition);
 
-    Position position = await _geolocator.getPosition();
+    Position position = await _geolocator.getPosition(LocationAccuracy.best);
 
     expect(position.latitude, _mockPosition['latitude']);
     expect(position.longitude, _mockPosition['longitude']);
@@ -96,10 +98,13 @@ void main() {
 
   group('Postion state changes', () {
     StreamController<Map<String, double>> _controller;
+    var _codedOptions = Codec.encodeLocationOptions(
+      LocationOptions(accuracy: LocationAccuracy.best, distanceFilter: 0));
 
     setUp(() {
+      
       _controller = new StreamController<Map<String, double>>();
-      when(_eventChannel.receiveBroadcastStream(LocationAccuracy.best.index))
+      when(_eventChannel.receiveBroadcastStream(_codedOptions))
           .thenReturn(_controller.stream);
     });
 
@@ -112,14 +117,14 @@ void main() {
       _geolocator.getPositionStream();
       _geolocator.getPositionStream();
 
-      verify(_eventChannel.receiveBroadcastStream(LocationAccuracy.best.index))
+      verify(_eventChannel.receiveBroadcastStream(_codedOptions))
           .called(1);
     });
 
     test('Receive position changes', () async {
       final StreamQueue<Position> queue = new StreamQueue<Position>(
           _geolocator.getPositionStream(LocationOptions(
-              accuracy: LocationAccuracy.best, distanceFilter: 10)));
+              accuracy: LocationAccuracy.best, distanceFilter: 0)));
 
       _controller.add(_mockPositions[0]);
       expect((await queue.next).toMap(), _mockPositions[0]);

--- a/test/geolocator_test.dart
+++ b/test/geolocator_test.dart
@@ -80,9 +80,9 @@ void main() {
   });
 
   test('Retrieve the current position', () async {
-    var codedOptions = Codec.encodeLocationOptions(LocationOptions(accuracy: LocationAccuracy.best, distanceFilter: 0));
-    when(_methodChannel.invokeMethod(
-            'getPosition', codedOptions))
+    var codedOptions = Codec.encodeLocationOptions(
+        LocationOptions(accuracy: LocationAccuracy.best, distanceFilter: 0));
+    when(_methodChannel.invokeMethod('getPosition', codedOptions))
         .thenAnswer((_) async => _mockPosition);
 
     Position position = await _geolocator.getPosition(LocationAccuracy.best);
@@ -99,10 +99,9 @@ void main() {
   group('Postion state changes', () {
     StreamController<Map<String, double>> _controller;
     var _codedOptions = Codec.encodeLocationOptions(
-      LocationOptions(accuracy: LocationAccuracy.best, distanceFilter: 0));
+        LocationOptions(accuracy: LocationAccuracy.best, distanceFilter: 0));
 
     setUp(() {
-      
       _controller = new StreamController<Map<String, double>>();
       when(_eventChannel.receiveBroadcastStream(_codedOptions))
           .thenReturn(_controller.stream);
@@ -117,8 +116,7 @@ void main() {
       _geolocator.getPositionStream();
       _geolocator.getPositionStream();
 
-      verify(_eventChannel.receiveBroadcastStream(_codedOptions))
-          .called(1);
+      verify(_eventChannel.receiveBroadcastStream(_codedOptions)).called(1);
     });
 
     test('Receive position changes', () async {

--- a/test/geolocator_test.dart
+++ b/test/geolocator_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:async/async.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/models/location_accuracy.dart';
+import 'package:geolocator/models/location_options.dart';
 import 'package:mockito/mockito.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:geolocator/models/position.dart';
@@ -117,7 +118,8 @@ void main() {
 
     test('Receive position changes', () async {
       final StreamQueue<Position> queue = new StreamQueue<Position>(
-          _geolocator.getPositionStream(LocationAccuracy.best));
+          _geolocator.getPositionStream(LocationOptions(
+              accuracy: LocationAccuracy.best, distanceFilter: 10)));
 
       _controller.add(_mockPositions[0]);
       expect((await queue.next).toMap(), _mockPositions[0]);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Currently it is not possible to configure a minimum distance change before updates are send to the App.

### :new: What is the new behavior (if this is a feature change)?

Allows the developer to configure a minimum distance in meters.

### :boom: Does this PR introduce a breaking change?

Yes, the signature of the `getPositionStream` method changed, now accepting an instance of the `LocationOptions` class. 

### :bug: Recommendations for testing

Run the example app

### :memo: Links to relevant issues/docs

- Fixes #27 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop