### PR TITLE
 Inform user when location services are disabled while stream is running

### DIFF
--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/StreamLocationTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/StreamLocationTask.java
@@ -3,6 +3,7 @@ package com.baseflow.flutter.plugin.geolocator.tasks;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
+import android.location.LocationProvider;
 import android.os.Bundle;
 import android.os.Looper;
 
@@ -87,23 +88,32 @@ public class StreamLocationTask extends LocationTask {
             if(isBetterLocation(location, mBestLocation) && location.getAccuracy() <= mDesiredAccuracy) {
                 mBestLocation = location;
                 getTaskContext().getResult().success(LocationMapper.toHashMap(location));
-                return;
             }
         }
 
         @Override
-        public void onStatusChanged(String s, int i, Bundle bundle) {
+        public void onStatusChanged(String provider, int status, Bundle bundle) {
+            if (status == LocationProvider.AVAILABLE) {
+                onProviderEnabled(provider);
+            } else if (status == LocationProvider.OUT_OF_SERVICE) {
+                onProviderDisabled(provider);
+            }
 
         }
 
         @Override
-        public void onProviderEnabled(String s) {
+        public void onProviderEnabled(String provider) {
 
         }
 
         @Override
-        public void onProviderDisabled(String s) {
-
+        public void onProviderDisabled(String provider) {
+            if(provider.equals(mActiveProvider)) {
+                getTaskContext().getResult().error(
+                        "ERROR_UPDATING_LOCATION",
+                        "The active location provider was disabled. Check if the location services are enabled in the device settings.",
+                        null);
+            }
         }
 
         float accuracyToFloat(GeolocationAccuracy accuracy) {

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -240,7 +240,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../.symlinks/flutter/ios-release/Flutter.framework",
+				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/geolocator/geolocator.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,11 +33,16 @@ class _MyAppState extends State<MyApp> {
     _positionSubscription = _geolocator
         .getPositionStream(LocationOptions(
             accuracy: LocationAccuracy.high, distanceFilter: 10))
+        .handleError((onError) {
+          setState(() {
+                      _position = null;
+                    });
+        })
         .listen((Position position) {
-      setState(() {
-        _position = position;
-      });
-    });
+          setState(() {
+            _position = position;
+          });
+        });
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,15 +34,14 @@ class _MyAppState extends State<MyApp> {
         .getPositionStream(LocationOptions(
             accuracy: LocationAccuracy.high, distanceFilter: 10))
         .handleError((onError) {
-          setState(() {
-                      _position = null;
-                    });
-        })
-        .listen((Position position) {
-          setState(() {
-            _position = position;
-          });
-        });
+      setState(() {
+        _position = null;
+      });
+    }).listen((Position position) {
+      setState(() {
+        _position = position;
+      });
+    });
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Currently the active stream doesn't inform the user when the platform (Android) stops transmitting location updates.

### :new: What is the new behavior (if this is a feature change)?

The active stream will return an error informing the user that the platform (Android) has stopped transmitting location updates.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

- run the example app and play a GPX/KML file with location updates;
- revoke the location permissions
- notice that the value for the "Current location" displays "Unknown".

### :memo: Links to relevant issues/docs

Fixes #43 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop