### PR TITLE
Added support for kCLLocationAccuracyBestForNavigation on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,12 @@ The table below outlines the accuracy options per platform:
 
 |            | Android    | iOS   |
 |------------|-----------:|------:|
-| **Lowest** | 500m       | 3000m |
-| **Low**    | 500m       | 1000m |    
-| **Medium** | 100 - 500m | 100m  |
-| **High**   | 0 - 100m   | 10m   |
-| **Best**   | 0 - 100m   | ~0m   |
+| **lowest** | 500m       | 3000m |
+| **low**    | 500m       | 1000m |    
+| **medium** | 100 - 500m | 100m  |
+| **high**   | 0 - 100m   | 10m   |
+| **best**   | 0 - 100m   | ~0m   |
+| **bestForNavigation** | 0 - 100m | [Optimized for navigation](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation) |
 
 ## Issues
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeolocationAccuracy.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeolocationAccuracy.java
@@ -11,6 +11,6 @@ public enum GeolocationAccuracy {
     Medium,
     @SerializedName("high")
     High,
-    @SerializedName("best")
+    @SerializedName(value = "best", alternate = "bestForNavigation")
     Best
 }

--- a/example/lib/widgets/current_location_widget.dart
+++ b/example/lib/widgets/current_location_widget.dart
@@ -39,7 +39,8 @@ class _LocationState extends State<CurrentLocationWidget> {
     Position position;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      position = await _geolocator.getPosition(LocationAccuracy.bestForNavigation);
+      position =
+          await _geolocator.getPosition(LocationAccuracy.bestForNavigation);
     } on PlatformException {
       position = null;
     }

--- a/example/lib/widgets/current_location_widget.dart
+++ b/example/lib/widgets/current_location_widget.dart
@@ -22,7 +22,7 @@ class _LocationState extends State<CurrentLocationWidget> {
 
     _geolocator
         .getPositionStream(LocationOptions(
-            accuracy: LocationAccuracy.high, distanceFilter: 10))
+            accuracy: LocationAccuracy.bestForNavigation, distanceFilter: 10))
         .handleError((onError) {
       setState(() {
         _position = null;
@@ -39,7 +39,7 @@ class _LocationState extends State<CurrentLocationWidget> {
     Position position;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      position = await _geolocator.getPosition(LocationAccuracy.high);
+      position = await _geolocator.getPosition(LocationAccuracy.bestForNavigation);
     } on PlatformException {
       position = null;
     }

--- a/ios/Classes/Data/LocationOptions.swift
+++ b/ios/Classes/Data/LocationOptions.swift
@@ -24,6 +24,7 @@ enum GeolocationAccuracy : String, Codable {
     case medium = "medium"
     case high = "high"
     case best = "best"
+    case bestForNavigation = "bestForNavigation"
     
     var clValue: CLLocationAccuracy {
         switch self {
@@ -37,6 +38,8 @@ enum GeolocationAccuracy : String, Codable {
             return kCLLocationAccuracyNearestTenMeters
         case .best:
             return kCLLocationAccuracyBest
+        case .bestForNavigation:
+            return kCLLocationAccuracyBestForNavigation
         }
     }
 }

--- a/lib/models/location_accuracy.dart
+++ b/lib/models/location_accuracy.dart
@@ -15,5 +15,8 @@ enum LocationAccuracy {
   high,
 
   /// Location is accurate within a distance of ~0m on iOS and between 0m and 100m on Android
-  best
+  best,
+
+  /// Location is accuracy is optimized for navigation on iOS and matches the [LocationAccuracy.best] on Android
+  bestForNavigation
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Currently the iOS accuracy `kCLLocationAccuracyBestForNavigation` is not supported.

### :new: What is the new behavior (if this is a feature change)?

Adds support for `kCLLocationAccuracyBestForNavigation` on iOS and defaults to `best` on Android.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run example app

### :memo: Links to relevant issues/docs

Resolves #48 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop