### PR TITLE
Remove GPS listener on task stop

### DIFF
--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CurrentLocationTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CurrentLocationTask.java
@@ -61,4 +61,14 @@ public class CurrentLocationTask extends LocationTask {
                 message,
                 null);
     }
+
+    @Override
+    public void stopTask() {
+        super.stopTask();
+
+        LocationManager locationManager = getLocationManager();
+        if(mLocationListener != null) {
+            locationManager.removeUpdates(mLocationListener);
+        }
+    }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/StreamLocationUpdatesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/StreamLocationUpdatesTask.java
@@ -14,7 +14,6 @@ public class StreamLocationUpdatesTask extends LocationTask {
 
     @Override
     protected void acquirePosition() {
-
         LocationManager locationManager = getLocationManager();
 
         // Make sure we remove existing listeners before we register a new one
@@ -61,5 +60,15 @@ public class StreamLocationUpdatesTask extends LocationTask {
                 code,
                 message,
                 null);
+    }
+
+    @Override
+    public void stopTask() {
+        super.stopTask();
+
+        LocationManager locationManager = getLocationManager();
+        if(mLocationListener != null) {
+            locationManager.removeUpdates(mLocationListener);
+        }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix. GPS listener was never removed on `Task` stop on android. This leak GPS tracking until app is killed.
iOS equivalent code:

https://github.com/BaseflowIT/flutter-geolocator/blob/c646e7bfe7dac2ba24ff9be8b0469b042c337072/ios/Classes/Tasks/LocationTask.swift#L52-L57

### :arrow_heading_down: What is the current behavior?

After stream cancel GPS tracking is leaked until app is killed.

### :new: What is the new behavior (if this is a feature change)?

After stream cancel GPS listener is removed.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

After `geolocator.getPositionStream.listen(<...>).cancel()` active GPS icon should disappear.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop