### PR TITLE
Bump version number and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
-## [1.4.0
+## [1.5.0]
+
+* It is now possible to check the location permissions using the `checkGeolocationStatus` method [[ISSUE #51](https://github.com/BaseflowIT/flutter-geolocator/issues/51)].
+* Improved the example App [[ISSUE #54](https://github.com/BaseflowIT/flutter-geolocator/issues/54)]
+* Solved a bug on Android causing a memory leak when you stop listening to the position stream.
+* **breaking** Solved a bug on Android where permissions could be requested more then once simultaniously [[ISSUE #58](https://github.com/BaseflowIT/flutter-geolocator/issues/58)]
+* Solved a bug on Android where requesting permissions twice would cause the App to crash [[ISSUE #61](https://github.com/BaseflowIT/flutter-geolocator/issues/61)]
+
+> **Important:**
+> 
+> To be able to correctly fix [issue #58](https://github.com/BaseflowIT/flutter-geolocator/issues/58) we had to change the `getPositionStream` method into a `async` method. This means the signature of the method has been changed from:
+>
+> `Stream<Position> getPositionStream([LocationOptions locationOptions = const LocationOptions()])` 
+>
+> to 
+>
+> `Future<Stream<Position>> getPositionStream([LocationOptions locationOptions = const LocationOptions()])`. 
+>
+> Meaning as a developer you'll now have to `await` the result of the method to get access to the actual stream.
+
+## [1.4.0]
 
 * Added feature to query the last known location that is stored on the device using the `getLastKnownLocation` method;
 * **breaking** Renamed the `getPosition` to `getCurrentPosition`;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: '^1.4.0'
+  geolocator: '^1.5.0'
 ```
 
 > **NOTE:** There's a known issue with integrating plugins that use Swift into a Flutter project created with the Objective-C template. See issue [Flutter#16049](https://github.com/flutter/flutter/issues/16049) for help on integration.

--- a/ios/geolocator.podspec
+++ b/ios/geolocator.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator'
-  s.version          = '1.4.0'
+  s.version          = '1.5.0'
   s.summary          = 'Geolocation plugin for Flutter. This plugin provides a cross-platform API for generic location (GPS etc.) functions.'
   s.description      = <<-DESC
 Geolocation plugin for Flutter.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 1.4.0
+version: 1.5.0
 author: Baseflow <hello@baseflow.com>
 homepage: https://github.com/baseflowit/flutter-geolocator
 


### PR DESCRIPTION
Prepare for release 1.5.0:

- Bump the version number to 1.5.0
- Update the changelog documenting all changes

This release solves the following issues:

- Fixes #51 
- Fixes #54 
- Fixes #58 
- Fixes #61