### PR TITLE
Set default distance filter value to 0m for FusedLocationProviderClient

### DIFF
--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
@@ -83,14 +83,10 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
     private LocationRequest createLocationRequest() {
         LocationRequest locationRequest = new LocationRequest();
 
-        float distanceFilter = mLocationOptions.distanceFilter > 0
-                ? mLocationOptions.distanceFilter
-                : 1;
-
         locationRequest
                 .setInterval(0)
                 .setFastestInterval(0)
-                .setSmallestDisplacement(distanceFilter);
+                .setSmallestDisplacement(mLocationOptions.distanceFilter);
 
         switch(mLocationOptions.accuracy) {
             case Low: case Lowest:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

- Currently location changes reported only when distance changes by at least 1m when using `FusedLocationProviderClient`. 
- All location changes reported when using `LocationManager` (distance filter 0 by default).

### :new: What is the new behavior (if this is a feature change)?

All locations changes reported by default for both location providers.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop