### PR TITLE
 Added feature to check availability of Google Play Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.3]
+
+* Added feature to check the availability of Google Play services on the device (using the `checkGooglePlayServicesAvailability` method). This will allow developers to implement a more user friendly experience regarding the usage of Google Play services (for more information see the article [Set Up Google Play Services](https://developers.google.com/android/guides/setup));
+* Fixed the error `'List<dynamic>' is not a subtype of type 'Future<dynamic>'` on Flutter 0.6.2 and higher (thanks @fawadkhanucp for reporting the issue and solution);
+* Fixed an error when calling the `getCurrentPosition`, `getPositionStream`, `placemarkFromAddress` and `placemarkFromCoordinates` from an Android background service (thanks @sestegra for reporting the issue and creating a pull-request).
+
 ## [1.6.2]
 
 * Hot fix to solve cast exception

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ master  | [![Build Status](https://travis-ci.com/BaseflowIT/flutter-geolocator.s
 * Get continuous location updates;
 * Check if location services are enabled on the device;
 * Translate an address to geocoordinates and vice verse (a.k.a. Geocoding);
-* Calculate the distance (in meters) between two geocoordinates.
+* Calculate the distance (in meters) between two geocoordinates;
+* Check the availability of Google Play services (on Android only).
 
 ## Usage
 
@@ -24,7 +25,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: '^1.6.2'
+  geolocator: '^1.6.3'
 ```
 
 > **NOTE:** There's a known issue with integrating plugins that use Swift into a Flutter project created with the Objective-C template. See issue [Flutter#16049](https://github.com/flutter/flutter/issues/16049) for help on integration.
@@ -87,7 +88,7 @@ If you want to translate latitude and longitude coordinates into an address you 
 ``` dart
 import 'package:geolocator/geolocator.dart';
 
-Placemark placemark = await new Geolocator().placemarkFromCoordinates(52.2165157, 6.9437819);
+Placemark placemark = await Geolocator().placemarkFromCoordinates(52.2165157, 6.9437819);
 ```
 
 ### Calculate distance
@@ -104,7 +105,18 @@ endLongitude | double | Longitude of the destination position
 ``` dart
 import 'package:geolocator/geolocator.dart';
 
-double distanceInMeters = await new Geolocator().distanceBetween(52.2165157, 6.9437819, 52.3546274, 4.8285838);
+double distanceInMeters = await Geolocator().distanceBetween(52.2165157, 6.9437819, 52.3546274, 4.8285838);
+```
+
+### Check the availability of Google Play services
+
+To check the availability of Google Play services on the current device, you can use the `checkGooglePlayServicesAvailability` method. This could be helpful to provide a more friendly experience to users in case an user-action is required to enable support for Google Play services (More information can be found [here](https://developers.google.com/android/guides/setup)). 
+
+``` dart
+import `package:geolocator/geolocator.dart`;
+
+GooglePlayServicesAvailability availability = 
+  await Geolocator().checkGooglePlayServicesAvailability();
 ```
 
 See also the [example](example/lib/main.dart) project for a complete implementation.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,7 +2,7 @@
 analyzer:
   strong-mode:
     implicit-casts: true
-    implicit-dynamic: true
+    implicit-dynamic: false
 
 # Source of linter options:
 # http://dart-lang.github.io/linter/lints/options/options.html

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/Codec.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/Codec.java
@@ -2,12 +2,20 @@ package com.baseflow.flutter.plugin.geolocator;
 
 import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 
+import com.baseflow.flutter.plugin.geolocator.data.PlayServicesAvailability;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class Codec {
-    private static final Gson GSON_DECODER = new Gson();
+    private static final Gson GSON_DECODER =
+            new GsonBuilder().enableComplexMapKeySerialization().create();
+
 
     public static LocationOptions decodeLocationOptions(Object arguments) {
         return GSON_DECODER.fromJson((String)arguments, LocationOptions.class);
+    }
+
+    public static String encodePlayServicesAvailability(PlayServicesAvailability availability) {
+        return GSON_DECODER.toJson(availability);
     }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/GeolocatorPlugin.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/GeolocatorPlugin.java
@@ -82,6 +82,13 @@ public class GeolocatorPlugin implements MethodCallHandler, EventChannel.StreamH
                 task.startTask();
                 break;
             }
+            case "checkPlayServicesAvailability": {
+                Task task = TaskFactory.createCheckPlayServicesAvailabilityTask(
+                        mRegistrar, result, call.arguments, this);
+                mTasks.put(task.getTaskID(), task);
+                task.startTask();
+                break;
+            }
             default:
                 result.notImplemented();
                 break;

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeolocationAccuracy.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeolocationAccuracy.java
@@ -4,13 +4,13 @@ import com.google.gson.annotations.SerializedName;
 
 public enum GeolocationAccuracy {
     @SerializedName("lowest")
-    Lowest,
+    LOWEST,
     @SerializedName("low")
-    Low,
+    LOW,
     @SerializedName("medium")
-    Medium,
+    MEDIUM,
     @SerializedName("high")
-    High,
+    HIGH,
     @SerializedName(value = "best", alternate = "bestForNavigation")
-    Best
+    BEST
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationOptions.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationOptions.java
@@ -1,6 +1,6 @@
 package com.baseflow.flutter.plugin.geolocator.data;
 
 public class LocationOptions {
-    public GeolocationAccuracy accuracy = GeolocationAccuracy.Best;
+    public GeolocationAccuracy accuracy = GeolocationAccuracy.BEST;
     public long distanceFilter = 0;
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PlayServicesAvailability.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PlayServicesAvailability.java
@@ -1,0 +1,20 @@
+package com.baseflow.flutter.plugin.geolocator.data;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum PlayServicesAvailability {
+    @SerializedName("success")
+    SUCCESS,
+    @SerializedName("serviceMissing")
+    SERVICE_MISSING,
+    @SerializedName("serviceUpdating")
+    SERVICE_UPDATING,
+    @SerializedName("serviceVersionUpdateRequired")
+    SERVICE_VERSION_UPDATE_REQUIRED,
+    @SerializedName("serviceDisabled")
+    SERVICE_DISABLED,
+    @SerializedName("serviceInvalid")
+    SERVICE_INVALID,
+    @SerializedName("unknown")
+    UNKNOWN
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CheckPlayServicesAvailabilityTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CheckPlayServicesAvailabilityTask.java
@@ -1,0 +1,74 @@
+package com.baseflow.flutter.plugin.geolocator.tasks;
+
+import android.content.Context;
+
+import com.baseflow.flutter.plugin.geolocator.Codec;
+import com.baseflow.flutter.plugin.geolocator.data.PlayServicesAvailability;
+import com.baseflow.flutter.plugin.geolocator.data.Result;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+
+import io.flutter.plugin.common.PluginRegistry;
+
+class CheckPlayServicesAvailabilityTask extends Task {
+    private final Context mContext;
+
+    public CheckPlayServicesAvailabilityTask(TaskContext taskContext) {
+        super(taskContext);
+
+        PluginRegistry.Registrar registry = taskContext.getRegistrar();
+        mContext = registry.activity() != null ? registry.activity() : registry.activeContext();
+    }
+
+    @Override
+    public void startTask() {
+        Result result = getTaskContext().getResult();
+
+        try {
+            GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
+
+            int connectionResult = googleApiAvailability.isGooglePlayServicesAvailable(mContext);
+            PlayServicesAvailability availability = toPlayServiceAvailability(connectionResult);
+
+            result.success(Codec.encodePlayServicesAvailability(availability));
+        } catch (Exception ex) {
+            result.error(
+                ex.getMessage(),
+                ex.getLocalizedMessage(),
+                null
+            );
+        } finally {
+            stopTask();
+        }
+    }
+
+    private static PlayServicesAvailability toPlayServiceAvailability(int connectionResult) {
+        PlayServicesAvailability availability;
+
+        switch(connectionResult) {
+            case ConnectionResult.SUCCESS:
+                availability = PlayServicesAvailability.SUCCESS;
+                break;
+            case ConnectionResult.SERVICE_MISSING:
+                availability = PlayServicesAvailability.SERVICE_MISSING;
+                break;
+            case ConnectionResult.SERVICE_UPDATING:
+                availability = PlayServicesAvailability.SERVICE_UPDATING;
+                break;
+            case ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED:
+                availability = PlayServicesAvailability.SERVICE_VERSION_UPDATE_REQUIRED;
+                break;
+            case ConnectionResult.SERVICE_DISABLED:
+                availability = PlayServicesAvailability.SERVICE_DISABLED;
+                break;
+            case ConnectionResult.SERVICE_INVALID:
+                availability = PlayServicesAvailability.SERVICE_INVALID;
+                break;
+            default:
+                availability = PlayServicesAvailability.UNKNOWN;
+                break;
+        }
+
+        return availability;
+    }
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
@@ -1,6 +1,6 @@
 package com.baseflow.flutter.plugin.geolocator.tasks;
 
-import android.app.Activity;
+import android.content.Context;
 import android.location.Address;
 import android.location.Geocoder;
 
@@ -10,15 +10,19 @@ import com.baseflow.flutter.plugin.geolocator.data.Result;
 import java.io.IOException;
 import java.util.List;
 
+import io.flutter.plugin.common.PluginRegistry;
+
 class ForwardGeocodingTask extends Task {
-    private final Activity mActivity;
+    private final Context mContext;
 
     private String mAddressToLookup;
 
     public ForwardGeocodingTask(TaskContext context) {
         super(context);
 
-        mActivity = context.getRegistrar().activity();
+        PluginRegistry.Registrar registrar = context.getRegistrar();
+
+        mContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
         mAddressToLookup = parseAddress(context.getArguments());
     }
 
@@ -30,7 +34,7 @@ class ForwardGeocodingTask extends Task {
 
     @Override
     public void startTask() {
-        Geocoder geocoder = new Geocoder(mActivity);
+        Geocoder geocoder = new Geocoder(mContext);
         Result result = getTaskContext().getResult();
 
         try {

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
@@ -89,27 +89,27 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
         criteria.setSpeedRequired(false);
 
         switch(accuracy) {
-            case Lowest:
+            case LOWEST:
                 criteria.setAccuracy(Criteria.NO_REQUIREMENT);
                 criteria.setHorizontalAccuracy(Criteria.NO_REQUIREMENT);
                 criteria.setPowerRequirement(Criteria.NO_REQUIREMENT);
                 break;
-            case Low:
+            case LOW:
                 criteria.setAccuracy(Criteria.ACCURACY_COARSE);
                 criteria.setHorizontalAccuracy(Criteria.ACCURACY_LOW);
                 criteria.setPowerRequirement(Criteria.NO_REQUIREMENT);
                 break;
-            case Medium:
+            case MEDIUM:
                 criteria.setAccuracy(Criteria.ACCURACY_COARSE);
                 criteria.setHorizontalAccuracy(Criteria.ACCURACY_MEDIUM);
                 criteria.setPowerRequirement(Criteria.POWER_MEDIUM);
                 break;
-            case High:
+            case HIGH:
                 criteria.setAccuracy(Criteria.ACCURACY_FINE);
                 criteria.setHorizontalAccuracy(Criteria.ACCURACY_HIGH);
                 criteria.setPowerRequirement(Criteria.POWER_HIGH);
                 break;
-            case Best:
+            case BEST:
                 criteria.setAccuracy(Criteria.ACCURACY_FINE);
                 criteria.setHorizontalAccuracy(Criteria.ACCURACY_HIGH);
                 criteria.setPowerRequirement(Criteria.POWER_HIGH);
@@ -167,10 +167,10 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
 
     private float accuracyToFloat(GeolocationAccuracy accuracy) {
         switch(accuracy) {
-            case Lowest: case Low: return 500;
-            case Medium: return 250;
-            case High: return 100;
-            case Best: return 50;
+            case LOWEST: case LOW: return 500;
+            case MEDIUM: return 250;
+            case HIGH: return 100;
+            case BEST: return 50;
             default: return 100;
         }
     }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
@@ -89,13 +89,13 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
                 .setSmallestDisplacement(mLocationOptions.distanceFilter);
 
         switch(mLocationOptions.accuracy) {
-            case Low: case Lowest:
+            case LOW: case LOWEST:
                 locationRequest.setPriority(LocationRequest.PRIORITY_LOW_POWER);
                 break;
-            case Medium:
+            case MEDIUM:
                 locationRequest.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
                 break;
-            case High: case Best:
+            case HIGH: case BEST:
                 locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
         }
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationManagerTask.java
@@ -21,7 +21,7 @@ abstract class LocationUsingLocationManagerTask extends Task {
 
         PluginRegistry.Registrar registrar = context.getRegistrar();
 
-        mContext = registrar.context();
+        mContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
         mLocationOptions = Codec.decodeLocationOptions(context.getArguments());
     }
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
@@ -1,6 +1,6 @@
 package com.baseflow.flutter.plugin.geolocator.tasks;
 
-import android.app.Activity;
+import android.content.Context;
 import android.location.Address;
 import android.location.Geocoder;
 
@@ -12,15 +12,19 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import io.flutter.plugin.common.PluginRegistry;
+
 class ReverseGeocodingTask extends Task {
-    private final Activity mActivity;
+    private final Context mContext;
 
     private Coordinate mCoordinatesToLookup;
 
     public ReverseGeocodingTask(TaskContext context) {
         super(context);
 
-        mActivity = context.getRegistrar().activity();
+        PluginRegistry.Registrar registrar = context.getRegistrar();
+
+        mContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
         mCoordinatesToLookup = parseCoordinates(context.getArguments());
     }
 
@@ -37,7 +41,7 @@ class ReverseGeocodingTask extends Task {
 
     @Override
     public void startTask() {
-        Geocoder geocoder = new Geocoder(mActivity);
+        Geocoder geocoder = new Geocoder(mContext);
         Result result = getTaskContext().getResult();
 
         try {

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskFactory.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskFactory.java
@@ -121,8 +121,23 @@ public class TaskFactory {
         }
     }
 
+    public static Task createCheckPlayServicesAvailabilityTask(
+            PluginRegistry.Registrar registrar,
+            MethodChannel.Result result,
+            Object arguments,
+            OnCompletionListener completionListener) {
+
+        TaskContext taskContext = TaskContext.buildFromMethodResult(
+                registrar,
+                result,
+                arguments,
+                completionListener);
+
+        return new CheckPlayServicesAvailabilityTask(taskContext);
+    }
+
     private static boolean isGooglePlayServicesAvailable(PluginRegistry.Registrar registrar) {
-        Context context = registrar.activity() == null ? registrar.activity() : registrar.activeContext();
+        Context context = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
 
         if (context == null) {
             return false;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,10 +3,11 @@ import 'package:flutter/material.dart';
 import 'pages/calculate_distance_widget.dart';
 import 'pages/current_location_widget.dart';
 import 'pages/location_stream_widget.dart';
+import 'pages/google_play_services_widget.dart';
 
 void main() => runApp(new GeolocatorExampleApp());
 
-enum TabItem { singleLocation, locationStream, distance }
+enum TabItem { singleLocation, locationStream, distance, googlePlayServices }
 
 class GeolocatorExampleApp extends StatefulWidget {
   @override
@@ -35,6 +36,8 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
         return LocationStreamWidget();
       case TabItem.distance:
         return CalculateDistanceWidget();
+      case TabItem.googlePlayServices:
+        return GooglePlayServicesWidget();
       case TabItem.singleLocation:
       default:
         return CurrentLocationWidget();
@@ -49,6 +52,7 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
             Icons.location_on, TabItem.singleLocation),
         _buildBottomNavigationBarItem(Icons.clear_all, TabItem.locationStream),
         _buildBottomNavigationBarItem(Icons.redo, TabItem.distance),
+        _buildBottomNavigationBarItem(Icons.adb, TabItem.googlePlayServices),
       ],
       onTap: _onSelectTab,
     );
@@ -83,6 +87,9 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
         break;
       case 2:
         selectedTabItem = TabItem.distance;
+        break;
+      case 3:
+        selectedTabItem = TabItem.googlePlayServices;
         break;
       default:
         selectedTabItem = TabItem.singleLocation;

--- a/example/lib/pages/google_play_services_widget.dart
+++ b/example/lib/pages/google_play_services_widget.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:geolocator/geolocator.dart';
+
+import '../common_widgets/placeholder_widget.dart';
+
+class GooglePlayServicesWidget extends StatefulWidget {
+  @override
+  _GooglePlayServicesState createState() => _GooglePlayServicesState();
+}
+
+class _GooglePlayServicesState extends State<GooglePlayServicesWidget> {
+  GooglePlayServicesAvailability _availability;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _initPlatformState();
+  }
+
+  // Platform messages are asynchronous, so we initialize in an async method.
+  void _initPlatformState() async {
+    GooglePlayServicesAvailability availability;
+    // Platform messages may fail, so we use a try/catch PlatformException.
+    try {
+      availability = await Geolocator().checkGooglePlayServicesAvailability();
+    } on PlatformException {
+      availability = GooglePlayServicesAvailability.unknown;
+    }
+
+    // If the widget was removed from the tree while the asynchronous platform
+    // message was in flight, we want to discard the reply rather than calling
+    // setState to update our non-existent appearance.
+    if (!mounted) return;
+
+    setState(() {
+      _availability = availability;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PlaceholderWidget("Google Play Services availability:\n",
+        _availability.toString().split('.').last);
+  }
+}

--- a/ios/geolocator.podspec
+++ b/ios/geolocator.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator'
-  s.version          = '1.6.2'
+  s.version          = '1.6.3'
   s.summary          = 'Geolocation plugin for Flutter. This plugin provides a cross-platform API for generic location (GPS etc.) functions.'
   s.description      = <<-DESC
 Geolocation plugin for Flutter.

--- a/lib/models/google_play_services_availability.dart
+++ b/lib/models/google_play_services_availability.dart
@@ -1,0 +1,27 @@
+part of geolocator;
+
+enum GooglePlayServicesAvailability {
+  /// Google Play services are installed on the device and ready to be used.
+  success,
+
+  /// Google Play services is missing on this device.
+  serviceMissing,
+
+  /// Google Play service is currently being updated on this device.
+  serviceUpdating,
+
+  /// The installed version of Google Play services is out of date.
+  serviceVersionUpdateRequired,
+
+  /// The installed version of Google Play services has been disabled on this device.
+  serviceDisabled,
+
+  /// The version of the Google Play services installed on this device is not authentic.
+  serviceInvalid,
+
+  /// Google Play services are not available on this platform.
+  notAvailableOnPlatform,
+
+  /// Unable to determine if Google Play services are installed.
+  unknown,
+}

--- a/lib/utils/codec.dart
+++ b/lib/utils/codec.dart
@@ -1,6 +1,15 @@
 part of geolocator;
 
 class Codec {
+  static GooglePlayServicesAvailability decodePlayServicesAvailability(
+      dynamic value) {
+    final dynamic availability = json.decode(value.toString());
+
+    return GooglePlayServicesAvailability.values.firstWhere(
+        (GooglePlayServicesAvailability e) =>
+            e.toString().split('.').last == availability);
+  }
+
   static String encodeLocationOptions(LocationOptions locationOptions) =>
       json.encode(_locationOptionsMap(locationOptions));
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 1.6.2
+version: 1.6.3
 author: Baseflow <hello@baseflow.com>
 homepage: https://github.com/baseflowit/flutter-geolocator
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature + bug fixes

### :arrow_heading_down: What is the current behavior?

The Geolocator plug-in can use Google Play services on Android to get access to more precise location updates. However in some situations the end-user needs to perform an action to make sure Google Play services is activated correctly. At the moment in these cases we automatically fallback to using the less precise `LocationManager`. 

### :new: What is the new behavior (if this is a feature change)?

This PR adds a feature that allow developers to check the availability of Google Play services and inform the end-user in case he or she need to perform an action to make Google Play services available and thus get the best possible performance.

Besides adding this feature, this PR also solves the following bugs:

- Runtime exception when trying to call the `getCurrentPosition`, `getPositionStream`, `placemarkFromAddress` and `placemarkFromCoordinates` from a background service on Android;
- Runtime exception when running the Geolocator plug-in on Flutter 0.6.2 and higher.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example app and check the `googlePlayServices` tab:

```shell
# Change into the example folder
cd example
# Run the Geolocator example App
flutter run
```

### :memo: Links to relevant issues/docs

- Resolves #75 
- Resolves #82 
- Resolves #84 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop