### PR TITLE
Add support to configure locale for Geocoding functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.6.4]
+
+* Added support to supply a locale when using the `placemarkFromAddress` and `placemarkFromCoordinates` methods.
+
 ## [1.6.3]
 
 * Added feature to check the availability of Google Play services on the device (using the `checkGooglePlayServicesAvailability` method). This will allow developers to implement a more user friendly experience regarding the usage of Google Play services (for more information see the article [Set Up Google Play Services](https://developers.google.com/android/guides/setup));

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: '^1.6.3'
+  geolocator: '^1.6.4'
 ```
 
 > **NOTE:** There's a known issue with integrating plugins that use Swift into a Flutter project created with the Objective-C template. See issue [Flutter#16049](https://github.com/flutter/flutter/issues/16049) for help on integration.
@@ -90,6 +90,16 @@ import 'package:geolocator/geolocator.dart';
 
 Placemark placemark = await Geolocator().placemarkFromCoordinates(52.2165157, 6.9437819);
 ```
+
+Both the `placemarkFromAddress` and `placemarkFromCoordinates` accept an optional `localeIdentifier` parameter. This paramter can be used to enforce the resulting placemark to be formatted (and translated) according to the specified locale. The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode]. Use the [ISO 639-1 or ISO 639-2](http://www.loc.gov/standards/iso639-2/php/English_list.php) standard for the language code and the 2 letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) standard for the country code. Some examples are:
+
+Locale identifier | Description
+----------------- | -----------
+en | All English speakers (will translate all attributes to English)
+en_US | English speakers in the United States of America
+en_UK | English speakers in the United Kingdom
+nl_NL | Dutch speakers in The Netherlands
+nl_BE | Dutch speakers in Belgium
 
 ### Calculate distance
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
@@ -6,9 +6,12 @@ import android.location.Geocoder;
 
 import com.baseflow.flutter.plugin.geolocator.data.AddressMapper;
 import com.baseflow.flutter.plugin.geolocator.data.Result;
+import com.baseflow.flutter.plugin.geolocator.utils.LocaleConverter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import io.flutter.plugin.common.PluginRegistry;
 
@@ -16,6 +19,7 @@ class ForwardGeocodingTask extends Task {
     private final Context mContext;
 
     private String mAddressToLookup;
+    private Locale mLocale;
 
     public ForwardGeocodingTask(TaskContext context) {
         super(context);
@@ -23,18 +27,23 @@ class ForwardGeocodingTask extends Task {
         PluginRegistry.Registrar registrar = context.getRegistrar();
 
         mContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
-        mAddressToLookup = parseAddress(context.getArguments());
+        parseArguments(context.getArguments());
     }
 
-    private static String parseAddress(Object arguments) {
-        if(arguments == null) return null;
+    private void parseArguments(Object arguments) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> argumentMap = (Map<String, String>)arguments;
 
-        return (String) arguments;
+        mAddressToLookup = argumentMap.get("address");
+
+        if (argumentMap.containsKey("localeIdentifier")) {
+            mLocale = LocaleConverter.fromLanguageTag((String)argumentMap.get("localeIdentifier"));
+        }
     }
 
     @Override
     public void startTask() {
-        Geocoder geocoder = new Geocoder(mContext);
+        Geocoder geocoder = new Geocoder(mContext, mLocale);
         Result result = getTaskContext().getResult();
 
         try {

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/utils/LocaleConverter.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/utils/LocaleConverter.java
@@ -1,0 +1,35 @@
+package com.baseflow.flutter.plugin.geolocator.utils;
+
+import java.util.Locale;
+import java.util.StringTokenizer;
+
+public class LocaleConverter {
+    private final static String LOCALE_DELIMITER = "_";
+
+    public static Locale fromLanguageTag(String languageTag) {
+        String language = null, country = null, variant = null;
+        StringTokenizer tokenizer = new StringTokenizer(languageTag, LOCALE_DELIMITER, false);
+
+        if(tokenizer.hasMoreTokens()) {
+            language = tokenizer.nextToken();
+        }
+
+        if(tokenizer.hasMoreTokens()) {
+            country = tokenizer.nextToken();
+        }
+
+        if(tokenizer.hasMoreTokens()) {
+            variant = tokenizer.nextToken();
+        }
+
+        if(language != null && country != null && variant != null) {
+            return new Locale(language, country, variant);
+        } else if (language != null && country != null) {
+            return new Locale(language, country);
+        } else if (language != null) {
+            return new Locale(language);
+        }
+
+        return null;
+    }
+}

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -467,6 +468,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/example/lib/pages/location_stream_widget.dart
+++ b/example/lib/pages/location_stream_widget.dart
@@ -121,8 +121,9 @@ class PositionListItemState extends State<PositionListItem> {
 
   void _onTap() async {
     String address = "unknown";
-    List<Placemark> placemarks = await Geolocator()
-        .placemarkFromCoordinates(_position.latitude, _position.longitude);
+    List<Placemark> placemarks = await Geolocator().placemarkFromCoordinates(
+        _position.latitude, _position.longitude,
+        localeIdentifier: "nl_NL");
 
     if (placemarks != null && placemarks.length > 0) {
       address = _buildAddressString(placemarks.first);

--- a/ios/geolocator.podspec
+++ b/ios/geolocator.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geolocator'
-  s.version          = '1.6.3'
+  s.version          = '1.6.4'
   s.summary          = 'Geolocation plugin for Flutter. This plugin provides a cross-platform API for generic location (GPS etc.) functions.'
   s.description      = <<-DESC
 Geolocation plugin for Flutter.

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -178,9 +178,18 @@ class Geolocator {
   /// In most situations the returned list should only contain one entry.
   /// However in some situations where the supplied address could not be
   /// resolved into a single [Placemark], multiple [Placemark] instances may be returned.
-  Future<List<Placemark>> placemarkFromAddress(String address) async {
+  ///
+  /// Optionally you can specify a locale in which the results are returned.
+  /// When not supplied the currently active locale of the device will be used.
+  Future<List<Placemark>> placemarkFromAddress(String address,
+      {String localeIdentifier}) async {
+    Map<String, String> parameters = <String, String>{"address": address};
+    if (localeIdentifier != null) {
+      parameters["localeIdentifier"] = localeIdentifier;
+    }
+
     List<dynamic> placemarks =
-        await _methodChannel.invokeMethod('placemarkFromAddress', address);
+        await _methodChannel.invokeMethod('placemarkFromAddress', parameters);
     return Placemark._fromMaps(placemarks);
   }
 
@@ -189,11 +198,23 @@ class Geolocator {
   /// In most situations the returned list should only contain one entry.
   /// However in some situations where the supplied coordinates could not be
   /// resolved into a single [Placemark], multiple [Placemark] instances may be returned.
+  ///
+  /// Optionally you can specify a locale in which the results are returned.
+  /// When not supplied the currently active locale of the device will be used.
   Future<List<Placemark>> placemarkFromCoordinates(
-      double latitude, double longitude) async {
+      double latitude, double longitude,
+      {String localeIdentifier}) async {
+    Map<String, dynamic> parameters = <String, dynamic>{
+      "latitude": latitude,
+      "longitude": longitude
+    };
+
+    if (localeIdentifier != null) {
+      parameters["localeIdentifier"] = localeIdentifier;
+    }
+
     List<dynamic> placemarks = await _methodChannel.invokeMethod(
-        'placemarkFromCoordinates',
-        <String, double>{"latitude": latitude, "longitude": longitude});
+        'placemarkFromCoordinates', parameters);
 
     try {
       return Placemark._fromMaps(placemarks);

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -181,7 +181,7 @@ class Geolocator {
   ///
   /// Optionally you can specify a locale in which the results are returned.
   /// When not supplied the currently active locale of the device will be used.
-  /// The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode].
+  /// The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode] (eg. en_US or nl_NL).
   Future<List<Placemark>> placemarkFromAddress(String address,
       {String localeIdentifier}) async {
     Map<String, String> parameters = <String, String>{"address": address};
@@ -202,7 +202,7 @@ class Geolocator {
   ///
   /// Optionally you can specify a locale in which the results are returned.
   /// When not supplied the currently active locale of the device will be used.
-  /// The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode].
+  /// The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode] (eg. en_US or nl_NL).
   Future<List<Placemark>> placemarkFromCoordinates(
       double latitude, double longitude,
       {String localeIdentifier}) async {

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -181,6 +181,7 @@ class Geolocator {
   ///
   /// Optionally you can specify a locale in which the results are returned.
   /// When not supplied the currently active locale of the device will be used.
+  /// The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode].
   Future<List<Placemark>> placemarkFromAddress(String address,
       {String localeIdentifier}) async {
     Map<String, String> parameters = <String, String>{"address": address};
@@ -201,6 +202,7 @@ class Geolocator {
   ///
   /// Optionally you can specify a locale in which the results are returned.
   /// When not supplied the currently active locale of the device will be used.
+  /// The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode].
   Future<List<Placemark>> placemarkFromCoordinates(
       double latitude, double longitude,
       {String localeIdentifier}) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 1.6.3
+version: 1.6.4
 author: Baseflow <hello@baseflow.com>
 homepage: https://github.com/baseflowit/flutter-geolocator
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

When using the `placemarkFromAddress` or `placemarkFromCoordinates` geocoding methods, the results are always formatted according to the locale of the device.

### :new: What is the new behavior (if this is a feature change)?

Added a parameter to supply a locale which will be used to format the result. If the parameter is not supplied the results will still be formatted according to the locale of the device.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

run the example app

```shell
# change into the example directory
cd example
# run the example app
flutter run
```

### :memo: Links to relevant issues/docs

- Fixes #90 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop