### PR TITLE
Added support to capture timestamp

### DIFF
--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationMapper.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationMapper.java
@@ -8,12 +8,13 @@ import java.util.Map;
 
 public class LocationMapper {
 
-    public static Map<String, Double> toHashMap(Location location)
+    public static Map<String, Object> toHashMap(Location location)
     {
-        Map<String, Double> position = new HashMap<>();
+        Map<String, Object> position = new HashMap<>();
 
         position.put("latitude", location.getLatitude());
         position.put("longitude", location.getLongitude());
+        position.put("timestamp", location.getTime());
 
         if(location.hasAltitude())
             position.put("altitude", location.getAltitude());
@@ -23,9 +24,8 @@ public class LocationMapper {
             position.put("heading", (double) location.getBearing());
         if(location.hasSpeed())
             position.put("speed", (double) location.getSpeed());
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasSpeedAccuracy()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasSpeedAccuracy())
             position.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
-        }
 
         return position;
     }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CalculateDistanceTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CalculateDistanceTask.java
@@ -11,7 +11,7 @@ class CalculateDistanceTask extends Task {
     private Coordinate mStartCoordinate;
     private Coordinate mEndCoordinate;
 
-    public CalculateDistanceTask(TaskContext context) {
+    CalculateDistanceTask(TaskContext context) {
         super(context);
 
         parseCoordinates(context.getArguments());

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CheckPlayServicesAvailabilityTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CheckPlayServicesAvailabilityTask.java
@@ -13,7 +13,7 @@ import io.flutter.plugin.common.PluginRegistry;
 class CheckPlayServicesAvailabilityTask extends Task {
     private final Context mContext;
 
-    public CheckPlayServicesAvailabilityTask(TaskContext taskContext) {
+    CheckPlayServicesAvailabilityTask(TaskContext taskContext) {
         super(taskContext);
 
         PluginRegistry.Registrar registry = taskContext.getRegistrar();

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
@@ -21,7 +21,7 @@ class ForwardGeocodingTask extends Task {
     private String mAddressToLookup;
     private Locale mLocale;
 
-    public ForwardGeocodingTask(TaskContext context) {
+    ForwardGeocodingTask(TaskContext context) {
         super(context);
 
         PluginRegistry.Registrar registrar = context.getRegistrar();
@@ -37,7 +37,7 @@ class ForwardGeocodingTask extends Task {
         mAddressToLookup = argumentMap.get("address");
 
         if (argumentMap.containsKey("localeIdentifier")) {
-            mLocale = LocaleConverter.fromLanguageTag((String)argumentMap.get("localeIdentifier"));
+            mLocale = LocaleConverter.fromLanguageTag(argumentMap.get("localeIdentifier"));
         }
     }
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
@@ -8,7 +8,7 @@ import com.baseflow.flutter.plugin.geolocator.data.Result;
 
 class LastKnownLocationUsingLocationManagerTask extends LocationUsingLocationManagerTask {
 
-    public LastKnownLocationUsingLocationManagerTask(TaskContext context) {
+    LastKnownLocationUsingLocationManagerTask(TaskContext context) {
         super(context);
     }
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
@@ -26,7 +26,7 @@ class LastKnownLocationUsingLocationServicesTask extends LocationUsingLocationSe
                 .addOnSuccessListener(new OnSuccessListener<Location>() {
                     @Override
                     public void onSuccess(Location location) {
-                        Map<String, Double> locationMap = location != null
+                        Map<String, Object> locationMap = location != null
                                 ? LocationMapper.toHashMap(location)
                                 : null;
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
@@ -20,7 +20,7 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
     private Location mBestLocation;
     private String mActiveProvider;
 
-    public LocationUpdatesUsingLocationManagerTask(TaskContext context, boolean stopAfterFirstLocationUpdate) {
+    LocationUpdatesUsingLocationManagerTask(TaskContext context, boolean stopAfterFirstLocationUpdate) {
         super(context);
 
         mStopAfterFirstLocationUpdate = stopAfterFirstLocationUpdate;
@@ -74,14 +74,14 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
         locationManager.removeUpdates(this);
     }
 
-    void handleError() {
+    private void handleError() {
         getTaskContext().getResult().error(
                 "INVALID_LOCATION_SETTINGS",
                 "Location settings are inadequate, check your location settings.",
                 null);
     }
 
-    String getBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy) {
+    private String getBestProvider(LocationManager locationManager, GeolocationAccuracy accuracy) {
         Criteria criteria = new Criteria();
 
         criteria.setBearingRequired(false);
@@ -176,7 +176,7 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
     }
 
     private void reportLocationUpdate(Location location) {
-        Map<String, Double> locationMap = LocationMapper.toHashMap(location);
+        Map<String, Object> locationMap = LocationMapper.toHashMap(location);
 
         getTaskContext().getResult().success(locationMap);
     }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
@@ -22,7 +22,7 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
     private final LocationCallback mLocationCallback;
 
 
-    public LocationUpdatesUsingLocationServicesTask(TaskContext taskContext, boolean stopAfterFirstLocationUpdate) {
+    LocationUpdatesUsingLocationServicesTask(TaskContext taskContext, boolean stopAfterFirstLocationUpdate) {
 
         super(taskContext);
 
@@ -48,7 +48,7 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
                 if (mStopAfterFirstLocationUpdate) {
                     stopTask();
                 }
-            };
+            }
         };
     }
 
@@ -103,7 +103,7 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
     }
 
     private void reportLocationUpdate(Location location) {
-        Map<String, Double> locationMap = LocationMapper.toHashMap(location);
+        Map<String, Object> locationMap = LocationMapper.toHashMap(location);
 
         getTaskContext().getResult().success(locationMap);
     }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationManagerTask.java
@@ -28,8 +28,7 @@ abstract class LocationUsingLocationManagerTask extends Task {
     public abstract void startTask();
 
     LocationManager getLocationManager() {
-        Context context = mContext;
-        return (LocationManager) context.getSystemService(Activity.LOCATION_SERVICE);
+        return (LocationManager) mContext.getSystemService(Activity.LOCATION_SERVICE);
     }
 
     public static boolean isBetterLocation(Location location, Location bestLocation) {

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationServicesTask.java
@@ -4,9 +4,9 @@ import com.baseflow.flutter.plugin.geolocator.Codec;
 import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 
 abstract class LocationUsingLocationServicesTask extends Task {
-    protected final LocationOptions mLocationOptions;
+    final LocationOptions mLocationOptions;
 
-    protected LocationUsingLocationServicesTask(TaskContext taskContext) {
+    LocationUsingLocationServicesTask(TaskContext taskContext) {
         super(taskContext);
 
         mLocationOptions = Codec.decodeLocationOptions(taskContext.getArguments());

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
@@ -17,14 +17,12 @@ import java.util.Map;
 import io.flutter.plugin.common.PluginRegistry;
 
 class ReverseGeocodingTask extends Task {
-    private static final String LOCALE_DELIMITER = "_";
-
     private final Context mContext;
 
     private Coordinate mCoordinatesToLookup;
     private Locale mLocale;
 
-    public ReverseGeocodingTask(TaskContext context) {
+    ReverseGeocodingTask(TaskContext context) {
         super(context);
 
         PluginRegistry.Registrar registrar = context.getRegistrar();

--- a/example/lib/pages/location_stream_widget.dart
+++ b/example/lib/pages/location_stream_widget.dart
@@ -112,9 +112,38 @@ class PositionListItemState extends State<PositionListItem> {
 
   @override
   Widget build(BuildContext context) {
+    Row row = Row(
+      children: <Widget>[
+        Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                "Lat: ${_position.latitude}",
+                style: TextStyle(fontSize: 16.0, color: Colors.black),
+              ),
+              Text(
+                "Lon: ${_position.longitude}",
+                style: TextStyle(fontSize: 16.0, color: Colors.black),
+              ),
+            ]),
+        Expanded(
+          child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  _position.timestamp.toLocal().toString(),
+                  style: TextStyle(fontSize: 14.0, color: Colors.grey),
+                )
+              ]),
+        ),
+      ],
+    );
+
     return ListTile(
       onTap: _onTap,
-      title: Text(_position.toString()),
+      title: row,
       subtitle: Text(_address),
     );
   }

--- a/ios/Classes/CLLocationExtensions.swift
+++ b/ios/Classes/CLLocationExtensions.swift
@@ -13,10 +13,17 @@ extension CLLocation {
         return [
             "latitude" : self.coordinate.latitude,
             "longitude" : self.coordinate.longitude,
+            "timestamp" : CLLocation.currentTimeInMilliSeconds(dateToConvert: self.timestamp),
             "altitude" : self.altitude,
             "accuracy" : self.horizontalAccuracy,
             "speed" : self.speed,
             "speed_accuracy" : 0.0
         ]
+    }
+    
+    private static func currentTimeInMilliSeconds(dateToConvert: Date)-> Int
+    {
+        let since1970 = dateToConvert.timeIntervalSince1970
+        return Int(since1970 * 1000)
     }
 }

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -53,8 +53,8 @@ class Geolocator {
   Future<GeolocationStatus> checkGeolocationPermissionStatus(
       {GeolocationPermission locationPermission =
           GeolocationPermission.location}) async {
-    PermissionStatus permissionStatus =
-        await PermissionHandler().checkPermissionStatus(
+    PermissionStatus permissionStatus = await PermissionHandler()
+        .checkPermissionStatus(
             _GeolocationStatusConverter.toPermissionGroup(locationPermission));
 
     return _GeolocationStatusConverter.fromPermissionStatus(permissionStatus);
@@ -141,7 +141,7 @@ class Geolocator {
             .receiveBroadcastStream(
                 Codec.encodeLocationOptions(locationOptions))
             .map<Position>((dynamic element) =>
-                Position._fromMap(element.cast<String, double>()));
+                Position._fromMap(element.cast<String, dynamic>()));
       }
 
       return _onPositionChanged;
@@ -153,14 +153,14 @@ class Geolocator {
   }
 
   Future<PermissionStatus> _getLocationPermission() async {
-    PermissionStatus permission =
-        await PermissionHandler().checkPermissionStatus(PermissionGroup.location);
+    PermissionStatus permission = await PermissionHandler()
+        .checkPermissionStatus(PermissionGroup.location);
 
     if (permission != PermissionStatus.granted &&
         permission != PermissionStatus.disabled) {
       Map<PermissionGroup, PermissionStatus> permissionStatus =
-          await PermissionHandler().requestPermissions(
-              [PermissionGroup.location]);
+          await PermissionHandler()
+              .requestPermissions([PermissionGroup.location]);
 
       return permissionStatus[PermissionGroup.location] ??
           PermissionStatus.unknown;

--- a/lib/models/position.dart
+++ b/lib/models/position.dart
@@ -5,6 +5,7 @@ class Position {
   Position._({
     this.longitude,
     this.latitude,
+    this.timestamp,
     this.accuracy,
     this.altitude,
     this.heading,
@@ -17,6 +18,9 @@ class Position {
 
   /// The longitude of the position in degrees normalized to the interval -180 (exclusive) to +180 (inclusive).
   final double longitude;
+
+  /// The time at which this position was determined.
+  final DateTime timestamp;
 
   /// The altitude of the device in meters.
   ///
@@ -74,26 +78,18 @@ class Position {
       throw new ArgumentError.value(positionMap, 'positionMap',
           'The supplied map doesn\'t contain the mandatory key `longitude`.');
 
+    final int timestamp = positionMap['timestamp'];
+
     return new Position._(
         latitude: positionMap['latitude'],
         longitude: positionMap['longitude'],
+        timestamp: (timestamp != null)
+            ? DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true)
+            : null,
         altitude: positionMap['altitude'] ?? 0.0,
         accuracy: positionMap['accuracy'] ?? 0.0,
         heading: positionMap['heading'] ?? 0.0,
         speed: positionMap['speed'] ?? 0.0,
         speedAccuracy: positionMap['speed_accuracy'] ?? 0.0);
-  }
-
-  @visibleForTesting
-  Map<String, double> toMap() {
-    return <String, double>{
-      'latitude': latitude,
-      'longitude': longitude,
-      'altitude': altitude,
-      'accuracy': accuracy,
-      'heading': heading,
-      'speed': speed,
-      'speed_accuracy': speedAccuracy
-    };
   }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

Currently the returned `Position` instance doesn't contain a timestamp indicating when the position was determined.

### :new: What is the new behavior (if this is a feature change)?

This PR adds a timestamp to the `Position` instance

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the example application (timestamp is shown on the location stream page):

```shell
# change into the example folder
cd example
# run the example app
flutter run
```

### :memo: Links to relevant issues/docs

- Fixes #98 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop