### PR TITLE
Added option to force plugin to use Android LocationManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To query the current location of the device simply make a call to the `getCurren
 ``` dart
 import 'package:geolocator/geolocator.dart';
 
-Position position = await Geolocator().getCurrentPosition(LocationAccuracy.high);
+Position position = await Geolocator().getCurrentPosition(desiredAccuracy: LocationAccuracy.high);
 ```
 
 To query the last known location retrieved stored on the device you can use the `getLastKnownPosition` method (note that this can result in a `null` value when no location details are available):
@@ -47,7 +47,7 @@ To query the last known location retrieved stored on the device you can use the 
 ``` dart
 import 'package:geolocator/geolocator.dart';
 
-Position position = await Geolocator().getLastKnownPosition(LocationAccuracy.high);
+Position position = await Geolocator().getLastKnownPosition(desiredAccuracy: LocationAccuracy.high);
 ```
 
 To listen for location changes you can subscribe to the `onPositionChanged` stream. Supply an instance of the `LocationOptions` class to configure

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/GeolocatorPlugin.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/GeolocatorPlugin.java
@@ -84,7 +84,7 @@ public class GeolocatorPlugin implements MethodCallHandler, EventChannel.StreamH
             }
             case "checkPlayServicesAvailability": {
                 Task task = TaskFactory.createCheckPlayServicesAvailabilityTask(
-                        mRegistrar, result, call.arguments, this);
+                        mRegistrar, result, this);
                 mTasks.put(task.getTaskID(), task);
                 task.startTask();
                 break;

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/CalculateDistanceOptions.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/CalculateDistanceOptions.java
@@ -1,0 +1,45 @@
+package com.baseflow.flutter.plugin.geolocator.data;
+
+import java.util.Map;
+
+public class CalculateDistanceOptions {
+    private Coordinate mSourceCoordinates;
+    private Coordinate mDestinationCoordinates;
+
+    public CalculateDistanceOptions(Coordinate sourceCoordinates, Coordinate destinationCoordinates) {
+        mSourceCoordinates = sourceCoordinates;
+        mDestinationCoordinates = destinationCoordinates;
+    }
+
+    public Coordinate getSourceCoordinates() {
+        return mSourceCoordinates;
+    }
+
+    public Coordinate getDestinationCoordinates() {
+        return mDestinationCoordinates;
+    }
+
+    public static CalculateDistanceOptions parseArguments(Object arguments) {
+        Coordinate sourceCoordinate;
+        Coordinate destinationCoordinate;
+
+        if(arguments == null) {
+            throw new IllegalArgumentException("No coordinates supplied to calculate distance between.");
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Double> coordinates = (Map<String, Double>)arguments;
+
+        if(coordinates == null)
+            throw new IllegalArgumentException("No coordinates supplied to calculate distance between.");
+
+        sourceCoordinate = new Coordinate(
+                coordinates.get("startLatitude"),
+                coordinates.get("startLongitude"));
+        destinationCoordinate = new Coordinate(
+                coordinates.get("endLatitude"),
+                coordinates.get("endLongitude"));
+
+        return new CalculateDistanceOptions(sourceCoordinate, destinationCoordinate);
+    }
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/ForwardGeocodingOptions.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/ForwardGeocodingOptions.java
@@ -1,0 +1,34 @@
+package com.baseflow.flutter.plugin.geolocator.data;
+
+import com.baseflow.flutter.plugin.geolocator.utils.LocaleConverter;
+
+import java.util.Locale;
+import java.util.Map;
+
+public class ForwardGeocodingOptions extends GeocodingOptions {
+    private String mAddressToLookup;
+
+    public ForwardGeocodingOptions(String addressToLookup, Locale locale) {
+        super(locale);
+
+        mAddressToLookup = addressToLookup;
+    }
+
+    public String getAddressToLookup() {
+        return mAddressToLookup;
+    }
+
+    public static ForwardGeocodingOptions parseArguments(Object arguments) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> argumentMap = (Map<String, String>)arguments;
+
+        String addressToLookup = argumentMap.get("address");
+        Locale locale = null;
+
+        if (argumentMap.containsKey("localeIdentifier")) {
+            locale = LocaleConverter.fromLanguageTag(argumentMap.get("localeIdentifier"));
+        }
+
+        return new ForwardGeocodingOptions(addressToLookup, locale);
+    }
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeocodingOptions.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/GeocodingOptions.java
@@ -1,0 +1,15 @@
+package com.baseflow.flutter.plugin.geolocator.data;
+
+import java.util.Locale;
+
+public abstract class GeocodingOptions {
+    private Locale mLocale;
+
+    public GeocodingOptions(Locale locale) {
+        mLocale = locale;
+    }
+
+    public Locale getLocale() {
+        return mLocale;
+    }
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationOptions.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/LocationOptions.java
@@ -1,6 +1,13 @@
 package com.baseflow.flutter.plugin.geolocator.data;
 
+import com.baseflow.flutter.plugin.geolocator.Codec;
+
 public class LocationOptions {
     public GeolocationAccuracy accuracy = GeolocationAccuracy.BEST;
     public long distanceFilter = 0;
+    public boolean forceAndroidLocationManager = false;
+
+    public static LocationOptions parseArguments(Object arguments) {
+        return Codec.decodeLocationOptions(arguments);
+    }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/ReverseGeocodingOptions.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/ReverseGeocodingOptions.java
@@ -1,0 +1,36 @@
+package com.baseflow.flutter.plugin.geolocator.data;
+
+import com.baseflow.flutter.plugin.geolocator.utils.LocaleConverter;
+
+import java.util.Locale;
+import java.util.Map;
+
+public class ReverseGeocodingOptions extends GeocodingOptions {
+    private Coordinate mCoordinate;
+
+    public ReverseGeocodingOptions(Coordinate coordinate, Locale locale) {
+        super(locale);
+
+        mCoordinate = coordinate;
+    }
+
+    public Coordinate getCoordinate() {
+         return mCoordinate;
+    }
+
+    public static ReverseGeocodingOptions parseArguments(Object arguments) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> argumentMap = (Map<String, Object>)arguments;
+
+        Locale locale = null;
+        Coordinate coordinate = new Coordinate(
+                (double)argumentMap.get("latitude"),
+                (double)argumentMap.get("longitude"));
+
+        if (argumentMap.containsKey("localeIdentifier")) {
+            locale = LocaleConverter.fromLanguageTag((String)argumentMap.get("localeIdentifier"));
+        }
+
+        return new ReverseGeocodingOptions(coordinate, locale);
+    }
+}

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CalculateDistanceTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CalculateDistanceTask.java
@@ -2,46 +2,24 @@ package com.baseflow.flutter.plugin.geolocator.tasks;
 
 import android.location.Location;
 
+import com.baseflow.flutter.plugin.geolocator.data.CalculateDistanceOptions;
 import com.baseflow.flutter.plugin.geolocator.data.Coordinate;
 import com.baseflow.flutter.plugin.geolocator.data.Result;
 
 import java.util.Map;
 
-class CalculateDistanceTask extends Task {
-    private Coordinate mStartCoordinate;
-    private Coordinate mEndCoordinate;
+class CalculateDistanceTask extends Task<CalculateDistanceOptions> {
 
-    CalculateDistanceTask(TaskContext context) {
+    CalculateDistanceTask(TaskContext<CalculateDistanceOptions> context) {
         super(context);
-
-        parseCoordinates(context.getArguments());
-    }
-
-    private void parseCoordinates(Object arguments) {
-        if(arguments == null) {
-            mStartCoordinate = null;
-            mEndCoordinate = null;
-        }
-
-        @SuppressWarnings("unchecked")
-        Map<String, Double> coordinates = (Map<String, Double>)arguments;
-
-        if(coordinates == null)
-            throw new IllegalArgumentException("No coordinates supplied to calculate distance between.");
-
-        mStartCoordinate = new Coordinate(
-                coordinates.get("startLatitude"),
-                coordinates.get("startLongitude"));
-        mEndCoordinate = new Coordinate(
-                coordinates.get("endLatitude"),
-                coordinates.get("endLongitude"));
     }
 
     @Override
     public void startTask() {
         Result flutterResult = getTaskContext().getResult();
+        CalculateDistanceOptions options = getTaskContext().getOptions();
 
-        if(mStartCoordinate == null || mEndCoordinate == null) {
+        if(options.getSourceCoordinates() == null || options.getDestinationCoordinates() == null) {
             flutterResult.error(
                     "ERROR_CALCULATE_DISTANCE_INVALID_PARAMS",
                     "Please supply start and end coordinates.",
@@ -52,10 +30,10 @@ class CalculateDistanceTask extends Task {
 
         try {
             Location.distanceBetween(
-                    mStartCoordinate.latitude,
-                    mStartCoordinate.longitude,
-                    mEndCoordinate.latitude,
-                    mEndCoordinate.longitude,
+                    options.getSourceCoordinates().latitude,
+                    options.getSourceCoordinates().longitude,
+                    options.getDestinationCoordinates().latitude,
+                    options.getDestinationCoordinates().longitude,
                     results);
 
             // According to the Android documentation the distance is

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CheckPlayServicesAvailabilityTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/CheckPlayServicesAvailabilityTask.java
@@ -10,10 +10,10 @@ import com.google.android.gms.common.GoogleApiAvailability;
 
 import io.flutter.plugin.common.PluginRegistry;
 
-class CheckPlayServicesAvailabilityTask extends Task {
+class CheckPlayServicesAvailabilityTask extends Task<Object> {
     private final Context mContext;
 
-    CheckPlayServicesAvailabilityTask(TaskContext taskContext) {
+    CheckPlayServicesAvailabilityTask(TaskContext<Object> taskContext) {
         super(taskContext);
 
         PluginRegistry.Registrar registry = taskContext.getRegistrar();

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
@@ -5,6 +5,7 @@ import android.location.Address;
 import android.location.Geocoder;
 
 import com.baseflow.flutter.plugin.geolocator.data.AddressMapper;
+import com.baseflow.flutter.plugin.geolocator.data.ForwardGeocodingOptions;
 import com.baseflow.flutter.plugin.geolocator.data.Result;
 import com.baseflow.flutter.plugin.geolocator.utils.LocaleConverter;
 
@@ -15,42 +16,29 @@ import java.util.Map;
 
 import io.flutter.plugin.common.PluginRegistry;
 
-class ForwardGeocodingTask extends Task {
+class ForwardGeocodingTask extends Task<ForwardGeocodingOptions> {
     private final Context mContext;
 
-    private String mAddressToLookup;
-    private Locale mLocale;
-
-    ForwardGeocodingTask(TaskContext context) {
+    ForwardGeocodingTask(TaskContext<ForwardGeocodingOptions> context) {
         super(context);
 
         PluginRegistry.Registrar registrar = context.getRegistrar();
 
         mContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
-        parseArguments(context.getArguments());
-    }
-
-    private void parseArguments(Object arguments) {
-        @SuppressWarnings("unchecked")
-        Map<String, String> argumentMap = (Map<String, String>)arguments;
-
-        mAddressToLookup = argumentMap.get("address");
-
-        if (argumentMap.containsKey("localeIdentifier")) {
-            mLocale = LocaleConverter.fromLanguageTag(argumentMap.get("localeIdentifier"));
-        }
     }
 
     @Override
     public void startTask() {
-        Geocoder geocoder = (mLocale != null)
-                ? new Geocoder(mContext, mLocale)
+        ForwardGeocodingOptions options = getTaskContext().getOptions();
+
+        Geocoder geocoder = (options.getLocale() != null)
+                ? new Geocoder(mContext, options.getLocale())
                 : new Geocoder(mContext);
 
         Result result = getTaskContext().getResult();
 
         try {
-            List<Address> addresses = geocoder.getFromLocationName(mAddressToLookup, 1);
+            List<Address> addresses = geocoder.getFromLocationName(options.getAddressToLookup(), 1);
 
             if(addresses.size() > 0) {
                 result.success(AddressMapper.toHashMapList(addresses));

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationManagerTask.java
@@ -10,25 +10,25 @@ import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 
 import io.flutter.plugin.common.PluginRegistry;
 
-abstract class LocationUsingLocationManagerTask extends Task {
+abstract class LocationUsingLocationManagerTask extends Task<LocationOptions> {
     private static final long TWO_MINUTES = 120000;
 
-    private final Context mContext;
+    private final Context mAndroidContext;
     final LocationOptions mLocationOptions;
 
-    LocationUsingLocationManagerTask(TaskContext context) {
+    LocationUsingLocationManagerTask(TaskContext<LocationOptions> context) {
         super(context);
 
         PluginRegistry.Registrar registrar = context.getRegistrar();
 
-        mContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
-        mLocationOptions = Codec.decodeLocationOptions(context.getArguments());
+        mAndroidContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
+        mLocationOptions = context.getOptions();
     }
 
     public abstract void startTask();
 
     LocationManager getLocationManager() {
-        return (LocationManager) mContext.getSystemService(Activity.LOCATION_SERVICE);
+        return (LocationManager) mAndroidContext.getSystemService(Activity.LOCATION_SERVICE);
     }
 
     public static boolean isBetterLocation(Location location, Location bestLocation) {

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUsingLocationServicesTask.java
@@ -1,14 +1,13 @@
 package com.baseflow.flutter.plugin.geolocator.tasks;
 
-import com.baseflow.flutter.plugin.geolocator.Codec;
 import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 
-abstract class LocationUsingLocationServicesTask extends Task {
+abstract class LocationUsingLocationServicesTask extends Task<LocationOptions> {
     final LocationOptions mLocationOptions;
 
-    LocationUsingLocationServicesTask(TaskContext taskContext) {
+    LocationUsingLocationServicesTask(TaskContext<LocationOptions> taskContext) {
         super(taskContext);
 
-        mLocationOptions = Codec.decodeLocationOptions(taskContext.getArguments());
+        mLocationOptions = taskContext.getOptions();
     }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
@@ -7,49 +7,35 @@ import android.location.Geocoder;
 import com.baseflow.flutter.plugin.geolocator.data.AddressMapper;
 import com.baseflow.flutter.plugin.geolocator.data.Coordinate;
 import com.baseflow.flutter.plugin.geolocator.data.Result;
-import com.baseflow.flutter.plugin.geolocator.utils.LocaleConverter;
+import com.baseflow.flutter.plugin.geolocator.data.ReverseGeocodingOptions;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import io.flutter.plugin.common.PluginRegistry;
 
-class ReverseGeocodingTask extends Task {
-    private final Context mContext;
+class ReverseGeocodingTask extends Task<ReverseGeocodingOptions> {
+    private final Context mAndroidContext;
 
     private Coordinate mCoordinatesToLookup;
     private Locale mLocale;
 
-    ReverseGeocodingTask(TaskContext context) {
+    ReverseGeocodingTask(TaskContext<ReverseGeocodingOptions> context) {
         super(context);
 
         PluginRegistry.Registrar registrar = context.getRegistrar();
 
-        mContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
-
-        parseArguments(context.getArguments());
-    }
-
-    private void parseArguments(Object arguments) {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> argumentMap = (Map<String, Object>)arguments;
-
-        mCoordinatesToLookup = new Coordinate(
-                (double)argumentMap.get("latitude"),
-                (double)argumentMap.get("longitude"));
-
-        if (argumentMap.containsKey("localeIdentifier")) {
-            mLocale = LocaleConverter.fromLanguageTag((String)argumentMap.get("localeIdentifier"));
-        }
+        mAndroidContext = registrar.activity() != null ? registrar.activity() : registrar.activeContext();
+        mCoordinatesToLookup = context.getOptions().getCoordinate();
+        mLocale = context.getOptions().getLocale();
     }
 
     @Override
     public void startTask() {
         Geocoder geocoder = (mLocale != null)
-                ? new Geocoder(mContext, mLocale)
-                : new Geocoder(mContext);
+                ? new Geocoder(mAndroidContext, mLocale)
+                : new Geocoder(mAndroidContext);
 
         Result result = getTaskContext().getResult();
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/Task.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/Task.java
@@ -4,11 +4,11 @@ import com.baseflow.flutter.plugin.geolocator.OnCompletionListener;
 
 import java.util.UUID;
 
-public abstract class Task {
+public abstract class Task<TOptions> {
     private final UUID mTaskID;
-    private final TaskContext mTaskContext;
+    private final TaskContext<TOptions> mTaskContext;
 
-    Task(TaskContext context) {
+    Task(TaskContext<TOptions> context) {
         mTaskID = UUID.randomUUID();
         mTaskContext = context;
     }
@@ -17,7 +17,7 @@ public abstract class Task {
         return mTaskID;
     }
 
-    TaskContext getTaskContext() {
+    TaskContext<TOptions> getTaskContext() {
         return mTaskContext;
     }
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskContext.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskContext.java
@@ -9,8 +9,8 @@ import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
 
-final class TaskContext {
-    private final Object mArguments;
+final class TaskContext<TOptions> {
+    private final TOptions mOptions;
     private final OnCompletionListener mCompletionListener;
     private final PluginRegistry.Registrar mRegistrar;
     private final Result mResult;
@@ -19,16 +19,16 @@ final class TaskContext {
     private TaskContext(
             PluginRegistry.Registrar registrar,
             Result result,
-            Object arguments,
+            TOptions options,
             OnCompletionListener completionListener) {
         mRegistrar = registrar;
         mResult = result;
-        mArguments = arguments;
+        mOptions = options;
         mCompletionListener = completionListener;
     }
 
-    public Object getArguments() {
-        return mArguments;
+    public TOptions getOptions() {
+        return mOptions;
     }
 
     public OnCompletionListener getCompletionListener() {
@@ -45,31 +45,31 @@ final class TaskContext {
         return mResult;
     }
 
-    public static TaskContext buildFromMethodResult(
+    public static <TOptions> TaskContext<TOptions> buildForMethodResult(
             PluginRegistry.Registrar registrar,
             MethodChannel.Result methodResult,
-            Object arguments,
+            TOptions options,
             OnCompletionListener completionListener) {
         Result result = new Result(methodResult);
 
         return new TaskContext(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
     }
 
-    public static TaskContext buildFromEventSink(
+    public static <TOptions> TaskContext<TOptions> buildForEventSink(
             PluginRegistry.Registrar registrar,
             EventChannel.EventSink eventSink,
-            Object arguments,
+            TOptions options,
             OnCompletionListener completionListener) {
         Result result = new Result(eventSink);
 
         return new TaskContext(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
     }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskFactory.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskFactory.java
@@ -1,8 +1,13 @@
 package com.baseflow.flutter.plugin.geolocator.tasks;
 
 import android.content.Context;
+import android.location.LocationProvider;
 
 import com.baseflow.flutter.plugin.geolocator.OnCompletionListener;
+import com.baseflow.flutter.plugin.geolocator.data.CalculateDistanceOptions;
+import com.baseflow.flutter.plugin.geolocator.data.ForwardGeocodingOptions;
+import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
+import com.baseflow.flutter.plugin.geolocator.data.ReverseGeocodingOptions;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 
@@ -17,10 +22,11 @@ public class TaskFactory {
             Object arguments,
             OnCompletionListener completionListener) {
 
-        TaskContext taskContext = TaskContext.buildFromMethodResult(
+        CalculateDistanceOptions options = CalculateDistanceOptions.parseArguments(arguments);
+        TaskContext taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
 
         return new CalculateDistanceTask(taskContext);
@@ -32,13 +38,14 @@ public class TaskFactory {
             Object arguments,
             OnCompletionListener completionListener) {
 
-        TaskContext taskContext = TaskContext.buildFromMethodResult(
+        LocationOptions options = LocationOptions.parseArguments(arguments);
+        TaskContext taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
 
-        if (isGooglePlayServicesAvailable(registrar)) {
+        if (!options.forceAndroidLocationManager && isGooglePlayServicesAvailable(registrar)) {
             return new LocationUpdatesUsingLocationServicesTask(
                     taskContext,
                     true);
@@ -55,10 +62,11 @@ public class TaskFactory {
             Object arguments,
             OnCompletionListener completionListener) {
 
-        TaskContext taskContext = TaskContext.buildFromMethodResult(
+        ForwardGeocodingOptions options = ForwardGeocodingOptions.parseArguments(arguments);
+        TaskContext taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
 
         return new ForwardGeocodingTask(taskContext);
@@ -70,13 +78,14 @@ public class TaskFactory {
             Object arguments,
             OnCompletionListener completionListener) {
 
-        TaskContext taskContext = TaskContext.buildFromMethodResult(
+        LocationOptions options = LocationOptions.parseArguments(arguments);
+        TaskContext taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
 
-        if (isGooglePlayServicesAvailable(registrar)) {
+        if (!options.forceAndroidLocationManager && isGooglePlayServicesAvailable(registrar)) {
             return new LastKnownLocationUsingLocationServicesTask(taskContext);
         } else {
             return new LastKnownLocationUsingLocationManagerTask(taskContext);
@@ -89,10 +98,11 @@ public class TaskFactory {
             Object arguments,
             OnCompletionListener completionListener) {
 
-        TaskContext taskContext = TaskContext.buildFromMethodResult(
+        ReverseGeocodingOptions options = ReverseGeocodingOptions.parseArguments(arguments);
+        TaskContext taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
 
         return new ReverseGeocodingTask(taskContext);
@@ -104,13 +114,14 @@ public class TaskFactory {
             Object arguments,
             OnCompletionListener completionListener) {
 
-        TaskContext taskContext = TaskContext.buildFromEventSink(
+        LocationOptions options = LocationOptions.parseArguments(arguments);
+        TaskContext taskContext = TaskContext.buildForEventSink(
                 registrar,
                 result,
-                arguments,
+                options,
                 completionListener);
 
-        if (isGooglePlayServicesAvailable(registrar)) {
+        if (!options.forceAndroidLocationManager && isGooglePlayServicesAvailable(registrar)) {
             return new LocationUpdatesUsingLocationServicesTask(
                     taskContext,
                     false);
@@ -124,13 +135,12 @@ public class TaskFactory {
     public static Task createCheckPlayServicesAvailabilityTask(
             PluginRegistry.Registrar registrar,
             MethodChannel.Result result,
-            Object arguments,
             OnCompletionListener completionListener) {
 
-        TaskContext taskContext = TaskContext.buildFromMethodResult(
+        TaskContext taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
-                arguments,
+                null,
                 completionListener);
 
         return new CheckPlayServicesAvailabilityTask(taskContext);

--- a/example/lib/pages/current_location_widget.dart
+++ b/example/lib/pages/current_location_widget.dart
@@ -23,8 +23,9 @@ class _LocationState extends State<CurrentLocationWidget> {
     Position position;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      position = await Geolocator()
-          .getCurrentPosition(LocationAccuracy.bestForNavigation);
+      position = await Geolocator().getCurrentPosition(
+          desiredAccuracy: LocationAccuracy.bestForNavigation,
+          forceAndroidLocationManager: true);
     } on PlatformException {
       position = null;
     }

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -63,13 +63,21 @@ class Geolocator {
   /// Returns the current position taking the supplied [desiredAccuracy] into account.
   ///
   /// When the [desiredAccuracy] is not supplied, it defaults to best.
+  ///
+  /// On Android devices you can set the parameter [forceAndroidLocationManager]
+  /// to true to force the plugin to use the [LocationManager] to determine the
+  /// position instead of the [FusedLocationProviderClient]. On iOS this
+  /// parameter is ignored.
   Future<Position> getCurrentPosition(
-      [LocationAccuracy desiredAccuracy = LocationAccuracy.best]) async {
+      {LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+      bool forceAndroidLocationManager = false}) async {
     PermissionStatus permission = await _getLocationPermission();
 
     if (permission == PermissionStatus.granted) {
-      LocationOptions locationOptions =
-          LocationOptions(accuracy: desiredAccuracy, distanceFilter: 0);
+      LocationOptions locationOptions = LocationOptions(
+          accuracy: desiredAccuracy,
+          distanceFilter: 0,
+          forceAndroidLocationManager: forceAndroidLocationManager);
       Map<dynamic, dynamic> positionMap = await _methodChannel.invokeMethod(
           'getCurrentPosition', Codec.encodeLocationOptions(locationOptions));
 
@@ -90,13 +98,21 @@ class Geolocator {
   /// On Android we look for the location provider matching best with the
   /// supplied [desiredAccuracy]. On iOS this parameter is ignored.
   /// When no position is available, null is returned.
+  ///
+  /// On Android devices you can set the parameter [forceAndroidLocationManager]
+  /// to true to force the plugin to use the [LocationManager] to determine the
+  /// position instead of the [FusedLocationProviderClient]. On iOS this
+  /// parameter is ignored.
   Future<Position> getLastKnownPosition(
-      [LocationAccuracy desiredAccuracy = LocationAccuracy.best]) async {
+      {LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+      bool forceAndroidLocationManager = false}) async {
     PermissionStatus permission = await _getLocationPermission();
 
     if (permission == PermissionStatus.granted) {
-      LocationOptions locationOptions =
-          LocationOptions(accuracy: desiredAccuracy, distanceFilter: 0);
+      LocationOptions locationOptions = LocationOptions(
+          accuracy: desiredAccuracy,
+          distanceFilter: 0,
+          forceAndroidLocationManager: forceAndroidLocationManager);
       Map<dynamic, dynamic> positionMap = await _methodChannel.invokeMethod(
           'getLastKnownPosition', Codec.encodeLocationOptions(locationOptions));
 

--- a/lib/models/location_options.dart
+++ b/lib/models/location_options.dart
@@ -3,10 +3,10 @@ part of geolocator;
 /// Represents different options to configure the quality and frequency
 /// of location updates.
 class LocationOptions {
-  const LocationOptions({
-    this.accuracy = LocationAccuracy.best,
-    this.distanceFilter = 0,
-  });
+  const LocationOptions(
+      {this.accuracy = LocationAccuracy.best,
+      this.distanceFilter = 0,
+      this.forceAndroidLocationManager = false});
 
   /// Defines the desired accuracy that should be used to determine the location data.
   ///
@@ -17,4 +17,9 @@ class LocationOptions {
   ///
   /// Supply 0 when you want to be notified of all movements. The default is 0.
   final int distanceFilter;
+
+  /// Forces the plugin to use the [LocationManager] on Android to acquire position fixes.
+  ///
+  /// On platforms other then Android this parameter is ignored.
+  final bool forceAndroidLocationManager;
 }

--- a/lib/utils/codec.dart
+++ b/lib/utils/codec.dart
@@ -21,6 +21,8 @@ class Codec {
           LocationOptions locationOptions) =>
       <String, dynamic>{
         "accuracy": Codec.encodeEnum(locationOptions.accuracy),
-        "distanceFilter": locationOptions.distanceFilter
+        "distanceFilter": locationOptions.distanceFilter,
+        "forceAndroidLocationManager":
+            locationOptions.forceAndroidLocationManager
       };
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

### :arrow_heading_down: What is the current behavior?

There is no way on Android to force the plugin to use the `LocationManager` instead of the `FusedLocationProviderClient` (the plugin will check if the `FusedLocationProviderClient` is available and only fallback to the `LocationManager` if it is not).

### :new: What is the new behavior (if this is a feature change)?

This PR adds an extra option to the `getCurrentPosition`, `getLastKnownPosition` methods and the `forceAndroidLocationManager` property on the `LocationOptions` class, which can be used to force the plugin to use the `LocationManager` even if the `FusedLocationProviderClient` is available.

### :boom: Does this PR introduce a breaking change?

**Yes**: the signature of the `getCurrentPosition` and `getLastKnowPosition` methods changed. Instead of taking one "positional optional parameter" they now take two "named optional parameters".

This means that if you currently specify a value for the optional parameter `desiredAccuracy` you will now have to include the name of the parameter in your method call (if you don't specify any parameters you don't have to update your code). For example:

** A call like this: **
```dart
Position position = await Geolocator().getCurrentPosition(LocationAccuracy.bestForNavigation);
``` 

** Should be updated to this: **
```dart
Position position = await Geolocator().getCurrentPosition(desiredAccuracy: LocationAccuracy.bestForNavigation);
```

### :bug: Recommendations for testing

Run the example App:

```shell
# Change into the "example" directory
cd example
# Run the example app
flutter run
```

### :memo: Links to relevant issues/docs

- Fixes #102 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop