### PR TITLE
Updated method signature

### DIFF
--- a/example/lib/pages/location_stream_widget.dart
+++ b/example/lib/pages/location_stream_widget.dart
@@ -14,12 +14,12 @@ class LocationStreamState extends State<LocationStreamWidget> {
   StreamSubscription<Position> _positionStreamSubscription;
   List<Position> _positions = <Position>[];
 
-  void _toggleListening() async {
+  void _toggleListening() {
     if (_positionStreamSubscription == null) {
       final LocationOptions locationOptions = const LocationOptions(
           accuracy: LocationAccuracy.best, distanceFilter: 10);
       final Stream<Position> positionStream =
-          await Geolocator().getPositionStream(locationOptions);
+          Geolocator().getPositionStream(locationOptions);
       _positionStreamSubscription = positionStream
           .listen((position) => setState(() => _positions.add(position)));
       _positionStreamSubscription.pause();

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -147,8 +147,8 @@ class Geolocator {
   /// You can customize the behaviour of the location updates by supplying an
   /// instance [LocationOptions] class. When you don't supply any specific
   /// options, default values will be used for each setting.
-  Future<Stream<Position>> getPositionStream(
-      [LocationOptions locationOptions = const LocationOptions()]) async {
+  Stream<Position> getPositionStream(
+      [LocationOptions locationOptions = const LocationOptions()]) async* {
     PermissionStatus permission = await _getLocationPermission();
 
     if (permission == PermissionStatus.granted) {
@@ -160,12 +160,10 @@ class Geolocator {
                 Position._fromMap(element.cast<String, dynamic>()));
       }
 
-      return _onPositionChanged;
+      yield* _onPositionChanged;
     } else {
       _handleInvalidPermissions(permission);
     }
-
-    return null;
   }
 
   Future<PermissionStatus> _getLocationPermission() async {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix / refactor

### :arrow_heading_down: What is the current behavior?

Currently you need to `await` the `getPositionStream` method to get the actual instance of the `Stream<Position>` class. This seems unnatural (see also #71)

### :new: What is the new behavior (if this is a feature change)?

Refactored the method so it is no longer necessary to `await` it.

### :boom: Does this PR introduce a breaking change?

Yes

### :bug: Recommendations for testing

Run the sample app

```shell
# Move to the example directory
cd example
# Run the example app
flutter run
```

### :memo: Links to relevant issues/docs

- Fixes #71

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop