### PR TITLE
Don't cast double to int

### DIFF
--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PositionMapper.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PositionMapper.java
@@ -6,7 +6,7 @@ import android.os.Build;
 import java.util.HashMap;
 import java.util.Map;
 
-public class LocationMapper {
+public class PositionMapper {
 
     public static Map<String, Object> toHashMap(Location location)
     {

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
@@ -3,7 +3,7 @@ package com.baseflow.flutter.plugin.geolocator.tasks;
 import android.location.Location;
 import android.location.LocationManager;
 
-import com.baseflow.flutter.plugin.geolocator.data.LocationMapper;
+import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.baseflow.flutter.plugin.geolocator.data.Result;
 
 class LastKnownLocationUsingLocationManagerTask extends LocationUsingLocationManagerTask {
@@ -33,7 +33,7 @@ class LastKnownLocationUsingLocationManagerTask extends LocationUsingLocationMan
             return;
         }
 
-        result.success(LocationMapper.toHashMap(bestLocation));
+        result.success(PositionMapper.toHashMap(bestLocation));
         stopTask();
     }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
@@ -3,7 +3,7 @@ package com.baseflow.flutter.plugin.geolocator.tasks;
 import android.location.Location;
 import android.support.annotation.NonNull;
 
-import com.baseflow.flutter.plugin.geolocator.data.LocationMapper;
+import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -27,7 +27,7 @@ class LastKnownLocationUsingLocationServicesTask extends LocationUsingLocationSe
                     @Override
                     public void onSuccess(Location location) {
                         Map<String, Object> locationMap = location != null
-                                ? LocationMapper.toHashMap(location)
+                                ? PositionMapper.toHashMap(location)
                                 : null;
 
                         getTaskContext().getResult().success(locationMap);

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
@@ -9,7 +9,7 @@ import android.os.Bundle;
 import android.os.Looper;
 
 import com.baseflow.flutter.plugin.geolocator.data.GeolocationAccuracy;
-import com.baseflow.flutter.plugin.geolocator.data.LocationMapper;
+import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.google.android.gms.common.util.Strings;
 
 import java.util.List;
@@ -176,7 +176,7 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
     }
 
     private void reportLocationUpdate(Location location) {
-        Map<String, Object> locationMap = LocationMapper.toHashMap(location);
+        Map<String, Object> locationMap = PositionMapper.toHashMap(location);
 
         getTaskContext().getResult().success(locationMap);
     }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
@@ -4,7 +4,7 @@ import android.location.Location;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 
-import com.baseflow.flutter.plugin.geolocator.data.LocationMapper;
+import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationRequest;
@@ -103,7 +103,7 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
     }
 
     private void reportLocationUpdate(Location location) {
-        Map<String, Object> locationMap = LocationMapper.toHashMap(location);
+        Map<String, Object> locationMap = PositionMapper.toHashMap(location);
 
         getTaskContext().getResult().success(locationMap);
     }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -242,12 +242,14 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/geolocator/geolocator.framework",
+				"${BUILT_PRODUCTS_DIR}/google_api_availability/google_api_availability.framework",
 				"${BUILT_PRODUCTS_DIR}/permission_handler/permission_handler.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/geolocator.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/google_api_availability.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/permission_handler.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Classes/CLLocationExtensions.swift
+++ b/ios/Classes/CLLocationExtensions.swift
@@ -21,9 +21,9 @@ extension CLLocation {
         ]
     }
     
-    private static func currentTimeInMilliSeconds(dateToConvert: Date)-> Int
+    private static func currentTimeInMilliSeconds(dateToConvert: Date)-> Double
     {
         let since1970 = dateToConvert.timeIntervalSince1970
-        return Int(since1970 * 1000)
+        return since1970 * 1000
     }
 }

--- a/lib/models/position.dart
+++ b/lib/models/position.dart
@@ -78,7 +78,7 @@ class Position {
       throw new ArgumentError.value(positionMap, 'positionMap',
           'The supplied map doesn\'t contain the mandatory key `longitude`.');
 
-    final int timestamp = positionMap['timestamp'];
+    final int timestamp = positionMap['timestamp'].toInt();
 
     return new Position._(
         latitude: positionMap['latitude'],


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug

### :arrow_heading_down: What is the current behavior?

Timestamp (double) is casted to `int` which could cause an overflow

### :new: What is the new behavior (if this is a feature change)?

Make sure the timestamp is not casted to an `int`

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run the sample app

### :memo: Links to relevant issues/docs

- Link #112 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop