### PR TITLE
Timestamp can be null when getting from map

### DIFF
--- a/lib/models/position.dart
+++ b/lib/models/position.dart
@@ -77,15 +77,15 @@ class Position {
     if (!positionMap.containsKey('longitude'))
       throw new ArgumentError.value(positionMap, 'positionMap',
           'The supplied map doesn\'t contain the mandatory key `longitude`.');
-
-    final int timestamp = positionMap['timestamp'].toInt();
+    
+    final DateTime timestamp = positionMap['timestamp'] != null ? DateTime
+        .fromMillisecondsSinceEpoch(
+        positionMap['timestamp'].toInt(), isUtc: true) : null;
 
     return new Position._(
         latitude: positionMap['latitude'],
         longitude: positionMap['longitude'],
-        timestamp: (timestamp != null)
-            ? DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true)
-            : null,
+        timestamp: timestamp,
         altitude: positionMap['altitude'] ?? 0.0,
         accuracy: positionMap['accuracy'] ?? 0.0,
         heading: positionMap['heading'] ?? 0.0,


### PR DESCRIPTION
Kept getting this error on `Geolocator().placemarkFromCoordinates(lat, lon)`:

```E/flutter ( 5311): [ERROR:flutter/shell/common/shell.cc(181)] Dart Error: Unhandled exception:
E/flutter ( 5311): NoSuchMethodError: The method 'toInt' was called on null.
E/flutter ( 5311): Receiver: null
E/flutter ( 5311): Tried calling: toInt()
```

Changed the constant and moved the logic to constant declaration itself. Have tested the change, it works.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
Crashing on `getPlacemarkForCoordinates`

### :new: What is the new behavior (if this is a feature change)?
Doesn't crash

### :boom: Does this PR introduce a breaking change?
Hope not :)

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop