### PR TITLE
Update analyze options to latest recommendations

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,6 +28,10 @@ analyzer:
     missing_return: warning
     # allow having TODOs in the code
     todo: ignore
+    # Ignore analyzer hints for updating pubspecs when using Future or
+    # Stream and not importing dart:async
+    # Please see https://github.com/flutter/flutter/pull/24528 for details.
+    #sdk_version_async_exported_from_core: ignore
   exclude:
     - 'bin/cache/**'
     # the following two are relative to the stocks example and the flutter package respectively
@@ -56,6 +60,7 @@ linter:
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
+    # - avoid_implementing_value_types # not yet tested
     - avoid_init_to_null
     # - avoid_js_rounded_ints # only useful when targeting JS runtime
     - avoid_null_checks_in_equality_operators
@@ -65,8 +70,11 @@ linter:
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     # - avoid_returning_null # there are plenty of valid reasons to return null
+    # - avoid_returning_null_for_future # not yet tested
+    - avoid_returning_null_for_void
     # - avoid_returning_this # there are plenty of valid reasons to return this
     # - avoid_setters_without_getters # not yet tested
+    # - avoid_shadowing_type_parameters # not yet tested
     # - avoid_single_cascade_in_expression_statements # not yet tested
     - avoid_slow_async_io
     - avoid_types_as_parameter_names
@@ -87,6 +95,7 @@ linter:
     - empty_constructor_bodies
     - empty_statements
     # - file_names # not yet tested
+    - flutter_style_todos
     - hash_and_equals
     - implementation_imports
     # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
@@ -111,7 +120,6 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -128,6 +136,7 @@ linter:
     # - prefer_function_declarations_over_variables # not yet tested
     - prefer_generic_function_type_aliases
     - prefer_initializing_formals
+    # - prefer_int_literals # not yet tested
     # - prefer_interpolation_to_compose_strings # not yet tested
     - prefer_is_empty
     - prefer_is_not_empty
@@ -140,6 +149,7 @@ linter:
     - recursive_getters
     - slash_for_doc_comments
     - sort_constructors_first
+    - sort_pub_dependencies
     - sort_unnamed_constructors_first
     - super_goes_last
     - test_types_in_equals
@@ -147,6 +157,7 @@ linter:
     # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
     # - unawaited_futures # too many false positives
+    # - unnecessary_await_in_return # not yet tested
     - unnecessary_brace_in_string_interps
     - unnecessary_const
     - unnecessary_getters_setters
@@ -159,6 +170,7 @@ linter:
     - unnecessary_statements
     - unnecessary_this
     - unrelated_type_equality_checks
+    # - use_function_type_syntax_for_parameters # not yet tested
     - use_rethrow_when_possible
     # - use_setters_to_change_properties # not yet tested
     # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Maintenance

### :arrow_heading_down: What is the current behavior?

Analyze options are outdated

### :new: What is the new behavior (if this is a feature change)?

Update analyze options to match with latest recommendations from Flutter team

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

run `flutter analyze`

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop