### PR TITLE
Feat/update google api availability for androidx

### DIFF
--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -72,7 +72,7 @@ class Geolocator {
     }
 
     _googlePlayServicesAvailability ??=
-        await GoogleApiAvailability().checkGooglePlayServicesAvailability();
+        await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
 
     return _googlePlayServicesAvailability !=
         GooglePlayServicesAvailability.success;

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -71,8 +71,8 @@ class Geolocator {
       return true;
     }
 
-    _googlePlayServicesAvailability ??=
-        await GoogleApiAvailability.instance.checkGooglePlayServicesAvailability();
+    _googlePlayServicesAvailability ??= await GoogleApiAvailability.instance
+        .checkGooglePlayServicesAvailability();
 
     return _googlePlayServicesAvailability !=
         GooglePlayServicesAvailability.success;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   permission_handler: "^2.2.0"
-  google_api_availability: "^1.0.6"
+  google_api_availability: "^2.0.0"
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR updates the dependency of the google_api_availability dependency to 2.0.0. This is the version that uses the AndroidX libraries instead of the old support libraries. The release build of my Flutter application fails because this dependency to the version with the old support library would collide with dependencies that expect the AndroidX libraries.

### :arrow_heading_down: What is the current behavior?
If the application that uses the library has other dependencies on libraries with that use AndroidX the release build would fail because of resource linking errors.


### :new: What is the new behavior (if this is a feature change)?
With the dependency to google_api_availability updated, the release build works fine

### :boom: Does this PR introduce a breaking change?
This is not really a breaking change since your library already did the chances for AndroidX. The dependency just still used an old version

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop