### PR TITLE
Bug heading on ios zero (Include the check on heading support to avoid dead lock)

### DIFF
--- a/ios/Classes/CLLocationExtensions.swift
+++ b/ios/Classes/CLLocationExtensions.swift
@@ -9,13 +9,14 @@ import Foundation
 import CoreLocation
 
 extension CLLocation {
-    public func toDictionary() -> NSDictionary {
+    public func toDictionary(heading: Double) -> NSDictionary {
         return [
             "latitude" : self.coordinate.latitude,
             "longitude" : self.coordinate.longitude,
             "timestamp" : CLLocation.currentTimeInMilliSeconds(dateToConvert: self.timestamp),
             "altitude" : self.altitude,
             "accuracy" : self.horizontalAccuracy,
+            "heading" : heading,
             "speed" : self.speed,
             "speed_accuracy" : 0.0
         ]

--- a/ios/Classes/CLPlacemarkExtensions.swift
+++ b/ios/Classes/CLPlacemarkExtensions.swift
@@ -24,7 +24,7 @@ extension CLPlacemark {
         ]
         
         if let location = self.location {
-            dict["location"] = location.toDictionary()
+            dict["location"] = location.toDictionary(heading:0.0)
         }
         
         return dict as NSDictionary

--- a/ios/Classes/Tasks/LastKnownLocationTask.swift
+++ b/ios/Classes/Tasks/LastKnownLocationTask.swift
@@ -18,7 +18,7 @@ class LastKnownLocationTask : Task, TaskProtocol {
         let locationManager = CLLocationManager.init()
         let location = locationManager.location;
         
-        guard let lastKnownPosition = location?.toDictionary() else {
+        guard let lastKnownPosition = location?.toDictionary(heading: 0.0) else {
             context.resultHandler(nil)
             return
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It includes in the return location the heading if it is available

### :arrow_heading_down: What is the current behavior?
The heading is always 0.0

### :new: What is the new behavior (if this is a feature change)?
When available the heading is filled.
A new location update is raised even if the GPS coordinate have not changed but the heading has.

### :boom: Does this PR introduce a breaking change?
Don't think so

### :bug: Recommendations for testing
Run the example app and look at the heading

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop