### PR TITLE
Detect mocked location

### DIFF
--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PositionMapper.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PositionMapper.java
@@ -6,8 +6,11 @@ import android.os.Build;
 import java.util.HashMap;
 import java.util.Map;
 
+import androidx.annotation.RequiresApi;
+
 public class PositionMapper {
 
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     public static Map<String, Object> toHashMap(Location location)
     {
         Map<String, Object> position = new HashMap<>();
@@ -15,6 +18,7 @@ public class PositionMapper {
         position.put("latitude", location.getLatitude());
         position.put("longitude", location.getLongitude());
         position.put("timestamp", location.getTime());
+        position.put("mocked", location.isFromMockProvider());
 
         if(location.hasAltitude())
             position.put("altitude", location.getAltitude());
@@ -26,7 +30,6 @@ public class PositionMapper {
             position.put("speed", (double) location.getSpeed());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasSpeedAccuracy())
             position.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
-
         return position;
     }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
@@ -2,9 +2,12 @@ package com.baseflow.flutter.plugin.geolocator.tasks;
 
 import android.location.Location;
 import android.location.LocationManager;
+import android.os.Build;
 
 import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.baseflow.flutter.plugin.geolocator.data.Result;
+
+import androidx.annotation.RequiresApi;
 
 class LastKnownLocationUsingLocationManagerTask extends LocationUsingLocationManagerTask {
 
@@ -12,6 +15,7 @@ class LastKnownLocationUsingLocationManagerTask extends LocationUsingLocationMan
         super(context);
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     @Override
     public void startTask() {
         LocationManager locationManager = getLocationManager();

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
@@ -5,6 +5,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.location.LocationProvider;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Looper;
 
@@ -14,6 +15,8 @@ import com.google.android.gms.common.util.Strings;
 
 import java.util.List;
 import java.util.Map;
+
+import androidx.annotation.RequiresApi;
 
 class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManagerTask implements LocationListener {
     private final boolean mStopAfterFirstLocationUpdate;
@@ -175,6 +178,7 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
         }
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     private void reportLocationUpdate(Location location) {
         Map<String, Object> locationMap = PositionMapper.toHashMap(location);
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
@@ -1,8 +1,10 @@
 package com.baseflow.flutter.plugin.geolocator.tasks;
 
 import android.location.Location;
+import android.os.Build;
 import android.os.Looper;
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 
 import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.google.android.gms.location.FusedLocationProviderClient;
@@ -102,6 +104,7 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
         return locationRequest;
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     private void reportLocationUpdate(Location location) {
         Map<String, Object> locationMap = PositionMapper.toHashMap(location);
 

--- a/lib/models/position.dart
+++ b/lib/models/position.dart
@@ -6,6 +6,7 @@ class Position {
     this.longitude,
     this.latitude,
     this.timestamp,
+    this.mocked,
     this.accuracy,
     this.altitude,
     this.heading,
@@ -17,6 +18,7 @@ class Position {
     this.longitude,
     this.latitude,
     this.timestamp,
+    this.mocked,
     this.accuracy,
     this.altitude,
     this.heading,
@@ -32,6 +34,11 @@ class Position {
 
   /// The time at which this position was determined.
   final DateTime timestamp;
+
+  ///Indicate if position was created from a mock provider.
+  ///
+  /// The mock information is not available on all devices. In these cases the returned value is false.
+  final bool mocked;
 
   /// The altitude of the device in meters.
   ///
@@ -98,6 +105,7 @@ class Position {
         latitude: positionMap['latitude'],
         longitude: positionMap['longitude'],
         timestamp: timestamp,
+        mocked: positionMap['mocked'] ?? false,
         altitude: positionMap['altitude'] ?? 0.0,
         accuracy: positionMap['accuracy'] ?? 0.0,
         heading: positionMap['heading'] ?? 0.0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 3.0.1
+version: 3.0.2
 author: Baseflow <hello@baseflow.com>
 homepage: https://github.com/baseflowit/flutter-geolocator
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Mocked location is not detected

### :new: What is the new behavior (if this is a feature change)?
Mocked location is now detected, and filled in "mocked" field from Position model.

### :boom: Does this PR introduce a breaking change?
Requires API 18 or higher.

### :bug: Recommendations for testing
Run the example app and look at the mocked value on "Current location" String.

### :memo: Links to relevant issues/docs
https://github.com/BaseflowIT/flutter-geolocator/issues/206

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop