### PR TITLE
change _position to position in stream section of README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var locationOptions = LocationOptions(accuracy: LocationAccuracy.high, distanceF
 
 StreamSubscription<Position> positionStream = geolocator.getPositionStream(locationOptions).listen(
     (Position position) {
-        print(_position == null ? 'Unknown' : _position.latitude.toString() + ', ' + _position.longitude.toString());
+        print(position == null ? 'Unknown' : position.latitude.toString() + ', ' + position.longitude.toString());
     });
 ```
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update

### :arrow_heading_down: What is the current behavior?
The code fails if variable _position (not used in this part of documentation) does not exist already.

### :new: What is the new behavior (if this is a feature change)?
It uses the Position object passed from stream as expected instead of class's object.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Not applied.

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop