### PR TITLE
added use_frameworks to ios part of instalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ If you would like to access the device's location when your App is running in th
 <string>This app needs access to location when open and in the background.</string>
 ```
 
+Make sure on your Podfile you have 
+```
+use_frameworks!
+```
+
 ### Location accuracy
 
 The table below outlines the accuracy options per platform:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Docs update: Added use_frameworks to part of instalation (this made me lost 2h to figure out)

### :arrow_heading_down: What is the current behavior?
If **use_frameworks!** is not available xcode will throw an error that it cannot find the file  
```
#import <geolocator/geolocator-Swift.h>
```

### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
https://github.com/BaseflowIT/flutter-geolocator/issues/17

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop