### PR TITLE
replace appcompat with core dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    api 'androidx.appcompat:appcompat:1.0.1'
+    api 'androidx.core:core:1.0.2'
     api 'com.google.android.gms:play-services-location:16.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Replace the AndroidX appcompat dependency with core as appcompat includes further dependencies while core does not. Geolocator does not require any classes from appcompat.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Build & Run on Android.

### :memo: Links to relevant issues/docs

https://developer.android.com/jetpack/androidx

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop