### PR TITLE
Changed geocoding execution to a separate thread using androids asynctask which handles serial execution of incoming task

### DIFF
--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import com.baseflow.flutter.plugin.geolocator.data.AddressMapper;
 import com.baseflow.flutter.plugin.geolocator.data.ForwardGeocodingOptions;
 import com.baseflow.flutter.plugin.geolocator.data.wrapper.ChannelResponse;
+import com.baseflow.flutter.plugin.geolocator.utils.MainThreadDispatcher;
 
 import java.io.IOException;
 import java.util.List;
@@ -43,20 +44,23 @@ class ForwardGeocodingTask extends Task<ForwardGeocodingOptions> {
                 try {
                     List<Address> addresses = geocoder.getFromLocationName(options.getAddressToLookup(), 1);
 
-                    if(addresses.size() > 0) {
-                        channelResponse.success(AddressMapper.toHashMapList(addresses));
+                    if (addresses.size() > 0) {
+                        MainThreadDispatcher.dispatchGeocodeResult(channelResponse, AddressMapper.toHashMapList(addresses));
                     } else {
-                        channelResponse.error(
+                        MainThreadDispatcher.dispatchError(
+                                channelResponse,
                                 "ERROR_GEOCODNG_ADDRESSNOTFOUND",
                                 "Unable to find coordinates matching the supplied address.",
-                                null);
+                                null
+                        );
                     }
-
                 } catch (IOException e) {
-                    channelResponse.error(
+                    MainThreadDispatcher.dispatchError(
+                            channelResponse,
                             "ERROR_GEOCODING_ADDRESS",
                             e.getLocalizedMessage(),
-                            null);
+                            null
+                    );
                 } finally {
                     stopTask();
                 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
@@ -45,7 +45,7 @@ class ForwardGeocodingTask extends Task<ForwardGeocodingOptions> {
                     List<Address> addresses = geocoder.getFromLocationName(options.getAddressToLookup(), 1);
 
                     if (addresses.size() > 0) {
-                        MainThreadDispatcher.dispatchGeocodeResult(channelResponse, AddressMapper.toHashMapList(addresses));
+                        MainThreadDispatcher.dispatchSuccess(channelResponse, AddressMapper.toHashMapList(addresses));
                     } else {
                         MainThreadDispatcher.dispatchError(
                                 channelResponse,

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ForwardGeocodingTask.java
@@ -3,6 +3,8 @@ package com.baseflow.flutter.plugin.geolocator.tasks;
 import android.content.Context;
 import android.location.Address;
 import android.location.Geocoder;
+import android.os.AsyncTask;
+import android.util.Log;
 
 import com.baseflow.flutter.plugin.geolocator.data.AddressMapper;
 import com.baseflow.flutter.plugin.geolocator.data.ForwardGeocodingOptions;
@@ -26,33 +28,39 @@ class ForwardGeocodingTask extends Task<ForwardGeocodingOptions> {
 
     @Override
     public void startTask() {
-        ForwardGeocodingOptions options = getTaskContext().getOptions();
+        final ForwardGeocodingOptions options = getTaskContext().getOptions();
 
-        Geocoder geocoder = (options.getLocale() != null)
+        final Geocoder geocoder = (options.getLocale() != null)
                 ? new Geocoder(mContext, options.getLocale())
                 : new Geocoder(mContext);
 
-        ChannelResponse channelResponse = getTaskContext().getResult();
+        final ChannelResponse channelResponse = getTaskContext().getResult();
 
-        try {
-            List<Address> addresses = geocoder.getFromLocationName(options.getAddressToLookup(), 1);
+        // let android handle the thread pool (uses shared serial executor)
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    List<Address> addresses = geocoder.getFromLocationName(options.getAddressToLookup(), 1);
 
-            if(addresses.size() > 0) {
-                channelResponse.success(AddressMapper.toHashMapList(addresses));
-            } else {
-                channelResponse.error(
-                        "ERROR_GEOCODNG_ADDRESSNOTFOUND",
-                        "Unable to find coordinates matching the supplied address.",
-                        null);
+                    if(addresses.size() > 0) {
+                        channelResponse.success(AddressMapper.toHashMapList(addresses));
+                    } else {
+                        channelResponse.error(
+                                "ERROR_GEOCODNG_ADDRESSNOTFOUND",
+                                "Unable to find coordinates matching the supplied address.",
+                                null);
+                    }
+
+                } catch (IOException e) {
+                    channelResponse.error(
+                            "ERROR_GEOCODING_ADDRESS",
+                            e.getLocalizedMessage(),
+                            null);
+                } finally {
+                    stopTask();
+                }
             }
-
-        } catch (IOException e) {
-            channelResponse.error(
-                    "ERROR_GEOCODING_ADDRESS",
-                    e.getLocalizedMessage(),
-                    null);
-        } finally {
-            stopTask();
-        }
+        });
     }
 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
@@ -4,12 +4,12 @@ import android.content.Context;
 import android.location.Address;
 import android.location.Geocoder;
 import android.os.AsyncTask;
-import android.util.Log;
 
 import com.baseflow.flutter.plugin.geolocator.data.AddressMapper;
 import com.baseflow.flutter.plugin.geolocator.data.Coordinate;
-import com.baseflow.flutter.plugin.geolocator.data.wrapper.ChannelResponse;
 import com.baseflow.flutter.plugin.geolocator.data.ReverseGeocodingOptions;
+import com.baseflow.flutter.plugin.geolocator.data.wrapper.ChannelResponse;
+import com.baseflow.flutter.plugin.geolocator.utils.MainThreadDispatcher;
 
 import java.io.IOException;
 import java.util.List;
@@ -48,20 +48,23 @@ class ReverseGeocodingTask extends Task<ReverseGeocodingOptions> {
                 try {
                     List<Address> addresses = geocoder.getFromLocation(mCoordinatesToLookup.latitude, mCoordinatesToLookup.longitude, 1);
 
-                    if(addresses.size() > 0) {
-                        channelResponse.success(AddressMapper.toHashMapList(addresses));
+                    if (addresses.size() > 0) {
+                        MainThreadDispatcher.dispatchGeocodeResult(channelResponse, AddressMapper.toHashMapList(addresses));
                     } else {
-                        channelResponse.error(
+                        MainThreadDispatcher.dispatchError(
+                                channelResponse,
                                 "ERROR_GEOCODING_INVALID_COORDINATES",
                                 "Unable to find an address for the supplied coordinates.",
-                                null);
+                                null
+                        );
                     }
-
                 } catch (IOException e) {
-                    channelResponse.error(
+                    MainThreadDispatcher.dispatchError(
+                            channelResponse,
                             "ERROR_GEOCODING_COORDINATES",
                             e.getLocalizedMessage(),
-                            null);
+                            null
+                    );
                 } finally {
                     stopTask();
                 }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/ReverseGeocodingTask.java
@@ -49,7 +49,7 @@ class ReverseGeocodingTask extends Task<ReverseGeocodingOptions> {
                     List<Address> addresses = geocoder.getFromLocation(mCoordinatesToLookup.latitude, mCoordinatesToLookup.longitude, 1);
 
                     if (addresses.size() > 0) {
-                        MainThreadDispatcher.dispatchGeocodeResult(channelResponse, AddressMapper.toHashMapList(addresses));
+                        MainThreadDispatcher.dispatchSuccess(channelResponse, AddressMapper.toHashMapList(addresses));
                     } else {
                         MainThreadDispatcher.dispatchError(
                                 channelResponse,

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/utils/MainThreadDispatcher.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/utils/MainThreadDispatcher.java
@@ -33,7 +33,7 @@ public class MainThreadDispatcher {
         });
     }
 
-    public static void dispatchGeocodeResult(@NonNull final ChannelResponse channelResponse, final Object result) {
+    public static void dispatchSuccess(@NonNull final ChannelResponse channelResponse, final Object result) {
         initHandlerIfNull();
         handler.post(new Runnable() {
             @Override

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/utils/MainThreadDispatcher.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/utils/MainThreadDispatcher.java
@@ -1,0 +1,45 @@
+package com.baseflow.flutter.plugin.geolocator.utils;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.baseflow.flutter.plugin.geolocator.data.wrapper.ChannelResponse;
+
+public class MainThreadDispatcher {
+    private static Handler handler = new Handler(Looper.getMainLooper());
+
+    public static void dispatch(Runnable runnable) {
+        initHandlerIfNull();
+        handler.post(runnable);
+    }
+
+    private static void initHandlerIfNull() {
+        if (handler == null) {
+            handler = new Handler(Looper.getMainLooper());
+        }
+    }
+
+    public static void dispatchError(@NonNull final ChannelResponse channelResponse, @NonNull final String channelName,
+                                     @NonNull final String error, @Nullable final Object details) {
+        initHandlerIfNull();
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                channelResponse.error(channelName, error, details);
+            }
+        });
+    }
+
+    public static void dispatchGeocodeResult(@NonNull final ChannelResponse channelResponse, final Object result) {
+        initHandlerIfNull();
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                channelResponse.success(result);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Changed geocoding task to run on a separate thread from main.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Enhancement on Geocoding performance.

### :arrow_heading_down: What is the current behavior?

Using Geocoding with native views introduces laggy experience, caused by UI thread blocking.
(Example google maps)

### :new: What is the new behavior (if this is a feature change)?

Running the Geocoding task on a separated thread, so it won't block the UI thread of Android Platform.

### :boom: Does this PR introduce a breaking change?

No. All the code that calls the Geocoding API is wrapped on a AsyncTask.

### :bug: Recommendations for testing

There are no tests submitted. Tested only locally.

### :thinking: Checklist before submitting

- [✔] All projects build
- [✔] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated. (No needed)
- [ ] Rebased onto current develop