### PR TITLE
Location fallback non gms

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PositionMapper.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/data/PositionMapper.java
@@ -3,14 +3,14 @@ package com.baseflow.flutter.plugin.geolocator.data;
 import android.location.Location;
 import android.os.Build;
 
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import java.util.HashMap;
 import java.util.Map;
 
 import androidx.annotation.RequiresApi;
 
 public class PositionMapper {
-
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     public static Map<String, Object> toHashMap(Location location)
     {
         Map<String, Object> position = new HashMap<>();
@@ -18,7 +18,9 @@ public class PositionMapper {
         position.put("latitude", location.getLatitude());
         position.put("longitude", location.getLongitude());
         position.put("timestamp", location.getTime());
-        position.put("mocked", location.isFromMockProvider());
+        if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
+            position.put("mocked", location.isFromMockProvider());
+        }
 
         if(location.hasAltitude())
             position.put("altitude", location.getAltitude());
@@ -28,7 +30,7 @@ public class PositionMapper {
             position.put("heading", (double) location.getBearing());
         if(location.hasSpeed())
             position.put("speed", (double) location.getSpeed());
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasSpeedAccuracy())
+        if (VERSION.SDK_INT >= VERSION_CODES.O && location.hasSpeedAccuracy())
             position.put("speed_accuracy", (double) location.getSpeedAccuracyMetersPerSecond());
         return position;
     }

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationManagerTask.java
@@ -4,6 +4,7 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.os.Build;
 
+import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.baseflow.flutter.plugin.geolocator.data.wrapper.ChannelResponse;
 
@@ -11,7 +12,7 @@ import androidx.annotation.RequiresApi;
 
 class LastKnownLocationUsingLocationManagerTask extends LocationUsingLocationManagerTask {
 
-    LastKnownLocationUsingLocationManagerTask(TaskContext context) {
+    LastKnownLocationUsingLocationManagerTask(TaskContext<LocationOptions> context) {
         super(context);
     }
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LastKnownLocationUsingLocationServicesTask.java
@@ -3,6 +3,7 @@ package com.baseflow.flutter.plugin.geolocator.tasks;
 import android.location.Location;
 import androidx.annotation.NonNull;
 
+import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
@@ -14,7 +15,7 @@ import java.util.Map;
 class LastKnownLocationUsingLocationServicesTask extends LocationUsingLocationServicesTask {
     private final FusedLocationProviderClient mFusedLocationProviderClient;
 
-    LastKnownLocationUsingLocationServicesTask(TaskContext taskContext) {
+    LastKnownLocationUsingLocationServicesTask(TaskContext<LocationOptions> taskContext) {
         super(taskContext);
 
         mFusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(taskContext.getAndroidContext());

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationManagerTask.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.os.Looper;
 
 import com.baseflow.flutter.plugin.geolocator.data.GeolocationAccuracy;
+import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.google.android.gms.common.util.Strings;
 
@@ -23,7 +24,7 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
     private Location mBestLocation;
     private String mActiveProvider;
 
-    LocationUpdatesUsingLocationManagerTask(TaskContext context, boolean stopAfterFirstLocationUpdate) {
+    LocationUpdatesUsingLocationManagerTask(TaskContext<LocationOptions> context, boolean stopAfterFirstLocationUpdate) {
         super(context);
 
         mStopAfterFirstLocationUpdate = stopAfterFirstLocationUpdate;
@@ -52,8 +53,9 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
 
         // If we are listening to multiple location updates we can go ahead
         // and report back the last known location (if we have one).
-        if(!mStopAfterFirstLocationUpdate && mBestLocation != null) {
+        if (mStopAfterFirstLocationUpdate && mBestLocation != null) {
             reportLocationUpdate(mBestLocation);
+            return;
         }
 
         Looper looper = Looper.myLooper();
@@ -137,7 +139,7 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
             mBestLocation = location;
             reportLocationUpdate(location);
 
-            if(mStopAfterFirstLocationUpdate) {
+            if (mStopAfterFirstLocationUpdate) {
                 this.stopTask();
             }
         }
@@ -178,7 +180,6 @@ class LocationUpdatesUsingLocationManagerTask extends LocationUsingLocationManag
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     private void reportLocationUpdate(Location location) {
         Map<String, Object> locationMap = PositionMapper.toHashMap(location);
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/LocationUpdatesUsingLocationServicesTask.java
@@ -6,6 +6,7 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 
+import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 import com.baseflow.flutter.plugin.geolocator.data.PositionMapper;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationCallback;
@@ -24,7 +25,7 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
     private final LocationCallback mLocationCallback;
 
 
-    LocationUpdatesUsingLocationServicesTask(TaskContext taskContext, boolean stopAfterFirstLocationUpdate) {
+    LocationUpdatesUsingLocationServicesTask(TaskContext<LocationOptions> taskContext, boolean stopAfterFirstLocationUpdate) {
 
         super(taskContext);
 
@@ -104,7 +105,6 @@ class LocationUpdatesUsingLocationServicesTask extends LocationUsingLocationServ
         return locationRequest;
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
     private void reportLocationUpdate(Location location) {
         Map<String, Object> locationMap = PositionMapper.toHashMap(location);
 

--- a/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskFactory.java
+++ b/android/src/main/java/com/baseflow/flutter/plugin/geolocator/tasks/TaskFactory.java
@@ -1,14 +1,10 @@
 package com.baseflow.flutter.plugin.geolocator.tasks;
 
-import android.content.Context;
-import android.location.LocationProvider;
-
 import com.baseflow.flutter.plugin.geolocator.OnCompletionListener;
 import com.baseflow.flutter.plugin.geolocator.data.CalculateDistanceOptions;
 import com.baseflow.flutter.plugin.geolocator.data.ForwardGeocodingOptions;
 import com.baseflow.flutter.plugin.geolocator.data.LocationOptions;
 import com.baseflow.flutter.plugin.geolocator.data.ReverseGeocodingOptions;
-
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
@@ -21,7 +17,7 @@ public class TaskFactory {
             OnCompletionListener completionListener) {
 
         CalculateDistanceOptions options = CalculateDistanceOptions.parseArguments(arguments);
-        TaskContext taskContext = TaskContext.buildForMethodResult(
+        TaskContext<CalculateDistanceOptions> taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
                 options,
@@ -37,7 +33,7 @@ public class TaskFactory {
             OnCompletionListener completionListener) {
 
         LocationOptions options = LocationOptions.parseArguments(arguments);
-        TaskContext taskContext = TaskContext.buildForMethodResult(
+        TaskContext<LocationOptions> taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
                 options,
@@ -61,7 +57,7 @@ public class TaskFactory {
             OnCompletionListener completionListener) {
 
         ForwardGeocodingOptions options = ForwardGeocodingOptions.parseArguments(arguments);
-        TaskContext taskContext = TaskContext.buildForMethodResult(
+        TaskContext<ForwardGeocodingOptions> taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
                 options,
@@ -77,7 +73,7 @@ public class TaskFactory {
             OnCompletionListener completionListener) {
 
         LocationOptions options = LocationOptions.parseArguments(arguments);
-        TaskContext taskContext = TaskContext.buildForMethodResult(
+        TaskContext<LocationOptions> taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
                 options,
@@ -97,7 +93,7 @@ public class TaskFactory {
             OnCompletionListener completionListener) {
 
         ReverseGeocodingOptions options = ReverseGeocodingOptions.parseArguments(arguments);
-        TaskContext taskContext = TaskContext.buildForMethodResult(
+        TaskContext<ReverseGeocodingOptions> taskContext = TaskContext.buildForMethodResult(
                 registrar,
                 result,
                 options,
@@ -113,7 +109,7 @@ public class TaskFactory {
             OnCompletionListener completionListener) {
 
         LocationOptions options = LocationOptions.parseArguments(arguments);
-        TaskContext taskContext = TaskContext.buildForEventSink(
+        TaskContext<LocationOptions> taskContext = TaskContext.buildForEventSink(
                 registrar,
                 result,
                 options,

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 02 13:17:18 CEST 2018
+#Mon May 20 11:10:40 BST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bugfix / Cleanup

### :arrow_heading_down: What is the current behavior?

- current location can not be determined (e.g. non-GMS enabled phones)
- various compiler warnings (about the SDK version, methods) which are incirrect

### :new: What is the new behavior (if this is a feature change)?

- current location can be determined again on such phones
- compiler warnings are removed

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Get a non-GMS phone (quite hard in EU/US, so import from China)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop