### PR TITLE
Allow specifying of location permission level while getting position

### DIFF
--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -80,8 +80,11 @@ class Geolocator {
   ///
   /// When the [desiredAccuracy] is not supplied, it defaults to best.
   Future<Position> getCurrentPosition(
-      {LocationAccuracy desiredAccuracy = LocationAccuracy.best, LocationPermissionLevel locationPermissionLevel = LocationPermissionLevel.location}) async {
-    final PermissionStatus permission = await _getLocationPermission(locationPermissionLevel);
+      {LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+      LocationPermissionLevel locationPermissionLevel =
+          LocationPermissionLevel.location}) async {
+    final PermissionStatus permission =
+        await _getLocationPermission(locationPermissionLevel);
 
     if (permission == PermissionStatus.granted) {
       final LocationOptions locationOptions = LocationOptions(
@@ -111,8 +114,11 @@ class Geolocator {
   /// supplied [desiredAccuracy]. On iOS this parameter is ignored.
   /// When no position is available, null is returned.
   Future<Position> getLastKnownPosition(
-      {LocationAccuracy desiredAccuracy = LocationAccuracy.best, LocationPermissionLevel locationPermissionLevel = LocationPermissionLevel.location}) async {
-    final PermissionStatus permission = await _getLocationPermission(locationPermissionLevel);
+      {LocationAccuracy desiredAccuracy = LocationAccuracy.best,
+      LocationPermissionLevel locationPermissionLevel =
+          LocationPermissionLevel.location}) async {
+    final PermissionStatus permission =
+        await _getLocationPermission(locationPermissionLevel);
 
     if (permission == PermissionStatus.granted) {
       final LocationOptions locationOptions = LocationOptions(
@@ -156,8 +162,11 @@ class Geolocator {
   /// instance [LocationOptions] class. When you don't supply any specific
   /// options, default values will be used for each setting.
   Stream<Position> getPositionStream(
-      [LocationOptions locationOptions = const LocationOptions(), LocationPermissionLevel locationPermissionLevel = LocationPermissionLevel.location] ) async* {
-    final PermissionStatus permission = await _getLocationPermission(locationPermissionLevel);
+      [LocationOptions locationOptions = const LocationOptions(),
+      LocationPermissionLevel locationPermissionLevel =
+          LocationPermissionLevel.location]) async* {
+    final PermissionStatus permission =
+        await _getLocationPermission(locationPermissionLevel);
 
     if (permission == PermissionStatus.granted) {
       _onPositionChanged ??= _eventChannel
@@ -171,7 +180,8 @@ class Geolocator {
     }
   }
 
-  Future<PermissionStatus> _getLocationPermission(LocationPermissionLevel locationPermissionLevel) async {
+  Future<PermissionStatus> _getLocationPermission(
+      LocationPermissionLevel locationPermissionLevel) async {
     final PermissionStatus permission = await LocationPermissions()
         .checkPermissionStatus(level: LocationPermissionLevel.location);
 

--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -80,8 +80,8 @@ class Geolocator {
   ///
   /// When the [desiredAccuracy] is not supplied, it defaults to best.
   Future<Position> getCurrentPosition(
-      {LocationAccuracy desiredAccuracy = LocationAccuracy.best}) async {
-    final PermissionStatus permission = await _getLocationPermission();
+      {LocationAccuracy desiredAccuracy = LocationAccuracy.best, LocationPermissionLevel locationPermissionLevel = LocationPermissionLevel.location}) async {
+    final PermissionStatus permission = await _getLocationPermission(locationPermissionLevel);
 
     if (permission == PermissionStatus.granted) {
       final LocationOptions locationOptions = LocationOptions(
@@ -111,8 +111,8 @@ class Geolocator {
   /// supplied [desiredAccuracy]. On iOS this parameter is ignored.
   /// When no position is available, null is returned.
   Future<Position> getLastKnownPosition(
-      {LocationAccuracy desiredAccuracy = LocationAccuracy.best}) async {
-    final PermissionStatus permission = await _getLocationPermission();
+      {LocationAccuracy desiredAccuracy = LocationAccuracy.best, LocationPermissionLevel locationPermissionLevel = LocationPermissionLevel.location}) async {
+    final PermissionStatus permission = await _getLocationPermission(locationPermissionLevel);
 
     if (permission == PermissionStatus.granted) {
       final LocationOptions locationOptions = LocationOptions(
@@ -156,8 +156,8 @@ class Geolocator {
   /// instance [LocationOptions] class. When you don't supply any specific
   /// options, default values will be used for each setting.
   Stream<Position> getPositionStream(
-      [LocationOptions locationOptions = const LocationOptions()]) async* {
-    final PermissionStatus permission = await _getLocationPermission();
+      [LocationOptions locationOptions = const LocationOptions(), LocationPermissionLevel locationPermissionLevel = LocationPermissionLevel.location] ) async* {
+    final PermissionStatus permission = await _getLocationPermission(locationPermissionLevel);
 
     if (permission == PermissionStatus.granted) {
       _onPositionChanged ??= _eventChannel
@@ -171,7 +171,7 @@ class Geolocator {
     }
   }
 
-  Future<PermissionStatus> _getLocationPermission() async {
+  Future<PermissionStatus> _getLocationPermission(LocationPermissionLevel locationPermissionLevel) async {
     final PermissionStatus permission = await LocationPermissions()
         .checkPermissionStatus(level: LocationPermissionLevel.location);
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix
Fixes #271 

### :arrow_heading_down: What is the current behavior?
iOS always uses location permission level Always.

### :new: What is the new behavior (if this is a feature change)?
added a optional parameter to include the locationpermissionlevel when requesting position.

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop