### PR TITLE
Stop location tracking on FlutterView destroy

### DIFF
--- a/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
+++ b/android/src/main/java/com/baseflow/geolocator/GeolocatorPlugin.java
@@ -14,11 +14,16 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterNativeView;
 
 /**
  * GeolocatorPlugin
  */
-public class GeolocatorPlugin implements MethodCallHandler, EventChannel.StreamHandler, OnCompletionListener {
+public class GeolocatorPlugin implements
+  MethodCallHandler,
+  EventChannel.StreamHandler,
+  OnCompletionListener,
+  PluginRegistry.ViewDestroyListener {
 
   private static final String METHOD_CHANNEL_NAME = "flutter.baseflow.com/geolocator/methods";
   private static final String EVENT_CHANNEL_NAME = "flutter.baseflow.com/geolocator/events";
@@ -43,6 +48,8 @@ public class GeolocatorPlugin implements MethodCallHandler, EventChannel.StreamH
     final EventChannel eventChannel = new EventChannel(registrar.messenger(), EVENT_CHANNEL_NAME);
     methodChannel.setMethodCallHandler(geolocatorPlugin);
     eventChannel.setStreamHandler(geolocatorPlugin);
+
+    registrar.addViewDestroyListener(geolocatorPlugin);
   }
 
   @Override
@@ -115,5 +122,11 @@ public class GeolocatorPlugin implements MethodCallHandler, EventChannel.StreamH
 
   public void onCompletion(UUID taskID) {
     mTasks.remove(taskID);
+  }
+
+  @Override
+  public boolean onViewDestroy(FlutterNativeView flutterNativeView) {
+    onCancel(null);
+    return false;
   }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for Androids' location stream.

### :arrow_heading_down: What is the current behavior?
Geolocator never unsubscribes from location tracking API when Flutter view is destroyed. So if activity is destroyed user still sees GPS icon in system bar.

### :new: What is the new behavior (if this is a feature change)?
Location listening task is stopped when view is destroyed.

### :boom: Does this PR introduce a breaking change?
There might be corner-case: If users were trying to track location after Activity is destroyed (another plugin returns `true` for `boolean onViewDestroy(FlutterNativeView flutterNativeView)`) then this change would break that behaviour. However that was if flawed and shouldn't be used because:
- It becomes impossible to stop location tracking.
- Since closing and reopening activities doesn't remove location updates callbacks then every activity (and flutter view) gets leaked.
Proper solution for these cases would be to use dedicated [FlutterNaviteView](https://api.flutter.dev/javadoc/io/flutter/view/FlutterNativeView.html#FlutterNativeView-android.content.Context-boolean-) with `isBackgroundView` set to `true`. 

### :bug: Recommendations for testing
To check existing problem:
1. Open geolocator example app -> 2nd tab (locationStream) -> click `Start listening`
2. Press android device `back` button. OR have toggled on `Do not keep activities` and minimize application.
3. Observe:
  - Logcat is spammed with message: `W/FlutterJNI( 6380): Tried to send a platform message to Flutter, but FlutterJNI was detached from native C++. Could not send. Channel: flutter.baseflow.com/geolocator/events. Response ID: 0`
  - GPS icon is still visible in System bar.
4. Re-open example app -> 2nd tab -> `Start listening` -> `Stop listening`. Gps icon do not disappear.
5. All resources are leaked.

Notes: on android >=28 this behavior (step 3) is not visible because location tracking is not permitted in background. But can be reproduced if application has Foreground service or another activity opened.

### :memo: Links to relevant issues/docs
https://github.com/flutter/flutter/issues/32818

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop