### PR TITLE
Include FusedLocationProvider usage in example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,7 +63,7 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
 
   BottomNavigationBarItem _buildBottomNavigationBarItem(
       IconData icon, TabItem tabItem) {
-    final String text = tabItem.toString().split('.').last;
+    final String text = _title(tabItem);
     final Color color =
         _currentItem == tabItem ? Theme.of(context).primaryColor : Colors.grey;
 
@@ -104,5 +104,20 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
     setState(() {
       _currentItem = selectedTabItem;
     });
+  }
+
+  String _title(TabItem item) {
+    switch (item) {
+      case TabItem.singleLocation:
+        return 'Single';
+      case TabItem.singleFusedLocation:
+        return 'Single (Fused)';
+      case TabItem.locationStream:
+        return 'Stream';
+      case TabItem.distance:
+        return 'Distance';
+      default:
+        throw 'Unknown: $item';
+    }
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'pages/calculate_distance_widget.dart';
@@ -6,7 +8,7 @@ import 'pages/location_stream_widget.dart';
 
 void main() => runApp(GeolocatorExampleApp());
 
-enum TabItem { singleLocation, locationStream, distance }
+enum TabItem { singleLocation, singleFusedLocation, locationStream, distance }
 
 class GeolocatorExampleApp extends StatefulWidget {
   @override
@@ -35,9 +37,11 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
         return LocationStreamWidget();
       case TabItem.distance:
         return CalculateDistanceWidget();
+      case TabItem.singleFusedLocation:
+        return CurrentLocationWidget(androidFusedLocation: true);
       case TabItem.singleLocation:
       default:
-        return CurrentLocationWidget();
+        return CurrentLocationWidget(androidFusedLocation: false);
     }
   }
 
@@ -47,6 +51,9 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
       items: <BottomNavigationBarItem>[
         _buildBottomNavigationBarItem(
             Icons.location_on, TabItem.singleLocation),
+        if (Platform.isAndroid)
+          _buildBottomNavigationBarItem(
+              Icons.location_on, TabItem.singleFusedLocation),
         _buildBottomNavigationBarItem(Icons.clear_all, TabItem.locationStream),
         _buildBottomNavigationBarItem(Icons.redo, TabItem.distance),
       ],
@@ -78,14 +85,20 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
     TabItem selectedTabItem;
 
     switch (index) {
+      case 0:
+        selectedTabItem = TabItem.singleLocation;
+        break;
       case 1:
-        selectedTabItem = TabItem.locationStream;
+        selectedTabItem = Platform.isAndroid
+            ? TabItem.singleFusedLocation
+            : TabItem.locationStream;
         break;
       case 2:
-        selectedTabItem = TabItem.distance;
+        selectedTabItem =
+            Platform.isAndroid ? TabItem.locationStream : TabItem.distance;
         break;
       default:
-        selectedTabItem = TabItem.singleLocation;
+        selectedTabItem = TabItem.distance;
     }
 
     setState(() {

--- a/example/lib/pages/current_location_widget.dart
+++ b/example/lib/pages/current_location_widget.dart
@@ -71,17 +71,11 @@ class _LocationState extends State<CurrentLocationWidget> {
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
-  Future<void> _initCurrentLocation() async {
-    // This timeout is managed by the Geolocator plugin internally.
-    // The FusedLocationProvider in Android will account for accurate & quick readings - therefore timeouts are not needed.
-    // If Geolocator uses the raw GPS sensor though, no data can be returned until the phone has an GPS signal (line of sight with the satellites).
-    final Duration timeout =
-        widget.androidFusedLocation ? Duration.zero : Duration(seconds: 5);
+  _initCurrentLocation() {
     Geolocator()
       ..forceAndroidLocationManager = !widget.androidFusedLocation
       ..getCurrentPosition(
         desiredAccuracy: LocationAccuracy.best,
-        timeout: timeout,
       ).then((position) {
         if (mounted) {
           setState(() => _currentPosition = position);

--- a/example/lib/pages/current_location_widget.dart
+++ b/example/lib/pages/current_location_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
@@ -5,6 +7,15 @@ import 'package:geolocator/geolocator.dart';
 import '../common_widgets/placeholder_widget.dart';
 
 class CurrentLocationWidget extends StatefulWidget {
+  const CurrentLocationWidget({
+    Key key,
+
+    /// If set, enable the FusedLocationProvider on Android
+    @required this.androidFusedLocation,
+  }) : super(key: key);
+
+  final bool androidFusedLocation;
+
   @override
   _LocationState createState() => _LocationState();
 }
@@ -16,6 +27,20 @@ class _LocationState extends State<CurrentLocationWidget> {
   @override
   void initState() {
     super.initState();
+
+    _initLastKnownLocation();
+    _initCurrentLocation();
+  }
+
+  @override
+  void didUpdateWidget(Widget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    setState(() {
+      _lastKnownPosition = null;
+      _currentPosition = null;
+    });
+
     _initLastKnownLocation();
     _initCurrentLocation();
   }
@@ -26,7 +51,7 @@ class _LocationState extends State<CurrentLocationWidget> {
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
       final Geolocator geolocator = Geolocator()
-        ..forceAndroidLocationManager = true;
+        ..forceAndroidLocationManager = !widget.androidFusedLocation;
       position = await geolocator.getLastKnownPosition(
           desiredAccuracy: LocationAccuracy.best);
     } on PlatformException {
@@ -47,27 +72,23 @@ class _LocationState extends State<CurrentLocationWidget> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> _initCurrentLocation() async {
-    Position position;
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    try {
-      final Geolocator geolocator = Geolocator()
-        ..forceAndroidLocationManager = true;
-      position = await geolocator.getCurrentPosition(
-          desiredAccuracy: LocationAccuracy.best);
-    } on PlatformException {
-      position = null;
-    }
-
-    // If the widget was removed from the tree while the asynchronous platform
-    // message was in flight, we want to discard the reply rather than calling
-    // setState to update our non-existent appearance.
-    if (!mounted) {
-      return;
-    }
-
-    setState(() {
-      _currentPosition = position;
-    });
+    // This timeout is managed by the Geolocator plugin internally.
+    // The FusedLocationProvider in Android will account for accurate & quick readings - therefore timeouts are not needed.
+    // If Geolocator uses the raw GPS sensor though, no data can be returned until the phone has an GPS signal (line of sight with the satellites).
+    final Duration timeout =
+        widget.androidFusedLocation ? Duration.zero : Duration(seconds: 5);
+    Geolocator()
+      ..forceAndroidLocationManager = !widget.androidFusedLocation
+      ..getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.best,
+        timeout: timeout,
+      ).then((position) {
+        if (mounted) {
+          setState(() => _currentPosition = position);
+        }
+      }).catchError((e) {
+        //
+      });
   }
 
   @override
@@ -90,6 +111,16 @@ class _LocationState extends State<CurrentLocationWidget> {
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 32,
+                    vertical: 16,
+                  ),
+                  child: Text(
+                    _fusedLocationNote(),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
                 PlaceholderWidget(
                     'Last known location:', _lastKnownPosition.toString()),
                 PlaceholderWidget(
@@ -98,5 +129,13 @@ class _LocationState extends State<CurrentLocationWidget> {
             ),
           );
         });
+  }
+
+  String _fusedLocationNote() {
+    if (widget.androidFusedLocation) {
+      return 'Geolocator is using the Android FusedLocationProvider. This requires Google Play Services to be installed on the target device.';
+    }
+
+    return 'Geolocator is using the raw location manager classes shipped with the operating system.';
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the geolocator plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Feature

![geolocator-example](https://user-images.githubusercontent.com/269860/59437703-a46bb600-8e24-11e9-81cd-c0a9919622c7.png)

### :arrow_heading_down: What is the current behavior?

Can not test FusedLocationProvider

### :new: What is the new behavior (if this is a feature change)?

Simple improvement to the example App to include an additional tab to test the FusedLocationProvider on Android.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

Build & Run Example Project.

### :memo: Links to relevant issues/docs

Extracted part of #282.

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop