### PR TITLE
Make _getLocationPermission use level parameter

### DIFF
--- a/lib/geolocator.dart
+++ b/lib/geolocator.dart
@@ -188,12 +188,11 @@ class Geolocator {
   Future<PermissionStatus> _getLocationPermission(
       LocationPermissionLevel locationPermissionLevel) async {
     final PermissionStatus permission = await LocationPermissions()
-        .checkPermissionStatus(level: LocationPermissionLevel.location);
+        .checkPermissionStatus(level: locationPermissionLevel);
 
     if (permission != PermissionStatus.granted) {
       final PermissionStatus permissionStatus = await LocationPermissions()
-          .requestPermissions(
-              permissionLevel: LocationPermissionLevel.location);
+          .requestPermissions(permissionLevel: locationPermissionLevel);
 
       return permissionStatus;
     } else {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

This PR continues on the work of https://github.com/BaseflowIT/flutter-geolocator/pull/276 by making `_getLocationPermission` use the `locationPermissionLevel` parameter.

### :arrow_heading_down: What is the current behavior?

Currently calls to `Geolocation.getCurrentLocation` are not affected by the `locationPermissionLevel`. This is because `_getLocationPermission` does not use the parameter, even though it is passed in to the function.

For example:

```
geolocation.getCurrentPosition(
          locationPermissionLevel: GeolocationPermission.locationWhenInUse);
```

Will show a dialog allowing the user to set background/when in use location permissions. 

### :new: What is the new behavior (if this is a feature change)?

The permission dialog shown will reflect the desired permissions based on the `locationPermissionLevel` parameter.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing



### :memo: Links to relevant issues/docs

#281 

https://github.com/BaseflowIT/flutter-geolocator/pull/294

https://github.com/BaseflowIT/flutter-geolocator/pull/276


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop