### PR TITLE
Bring back geocode example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:geolocator_example/pages/lookup_address_widget.dart';
 
 import 'pages/calculate_distance_widget.dart';
 import 'pages/current_location_widget.dart';
@@ -8,7 +9,13 @@ import 'pages/location_stream_widget.dart';
 
 void main() => runApp(GeolocatorExampleApp());
 
-enum TabItem { singleLocation, singleFusedLocation, locationStream, distance }
+enum TabItem {
+  singleLocation,
+  singleFusedLocation,
+  locationStream,
+  distance,
+  geocode
+}
 
 class GeolocatorExampleApp extends StatefulWidget {
   @override
@@ -17,6 +24,13 @@ class GeolocatorExampleApp extends StatefulWidget {
 
 class BottomNavigationState extends State<GeolocatorExampleApp> {
   TabItem _currentItem = TabItem.singleLocation;
+  final List<TabItem> _bottomTabs = [
+    TabItem.singleLocation,
+    if (Platform.isAndroid) TabItem.singleFusedLocation,
+    TabItem.locationStream,
+    TabItem.distance,
+    TabItem.geocode,
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -39,6 +53,8 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
         return CalculateDistanceWidget();
       case TabItem.singleFusedLocation:
         return CurrentLocationWidget(androidFusedLocation: true);
+      case TabItem.geocode:
+        return LookupAddressWidget();
       case TabItem.singleLocation:
       default:
         return CurrentLocationWidget(androidFusedLocation: false);
@@ -48,15 +64,10 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
   Widget _buildBottomNavigationBar() {
     return BottomNavigationBar(
       type: BottomNavigationBarType.fixed,
-      items: <BottomNavigationBarItem>[
-        _buildBottomNavigationBarItem(
-            Icons.location_on, TabItem.singleLocation),
-        if (Platform.isAndroid)
-          _buildBottomNavigationBarItem(
-              Icons.location_on, TabItem.singleFusedLocation),
-        _buildBottomNavigationBarItem(Icons.clear_all, TabItem.locationStream),
-        _buildBottomNavigationBarItem(Icons.redo, TabItem.distance),
-      ],
+      items: _bottomTabs
+          .map((tabItem) =>
+              _buildBottomNavigationBarItem(_icon(tabItem), tabItem))
+          .toList(),
       onTap: _onSelectTab,
     );
   }
@@ -82,24 +93,7 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
   }
 
   void _onSelectTab(int index) {
-    TabItem selectedTabItem;
-
-    switch (index) {
-      case 0:
-        selectedTabItem = TabItem.singleLocation;
-        break;
-      case 1:
-        selectedTabItem = Platform.isAndroid
-            ? TabItem.singleFusedLocation
-            : TabItem.locationStream;
-        break;
-      case 2:
-        selectedTabItem =
-            Platform.isAndroid ? TabItem.locationStream : TabItem.distance;
-        break;
-      default:
-        selectedTabItem = TabItem.distance;
-    }
+    TabItem selectedTabItem = _bottomTabs[index];
 
     setState(() {
       _currentItem = selectedTabItem;
@@ -116,6 +110,25 @@ class BottomNavigationState extends State<GeolocatorExampleApp> {
         return 'Stream';
       case TabItem.distance:
         return 'Distance';
+      case TabItem.geocode:
+        return 'Geocode';
+      default:
+        throw 'Unknown: $item';
+    }
+  }
+
+  IconData _icon(TabItem item) {
+    switch (item) {
+      case TabItem.singleLocation:
+        return Icons.location_on;
+      case TabItem.singleFusedLocation:
+        return Icons.location_on;
+      case TabItem.locationStream:
+        return Icons.clear_all;
+      case TabItem.distance:
+        return Icons.redo;
+      case TabItem.geocode:
+        return Icons.compare_arrows;
       default:
         throw 'Unknown: $item';
     }

--- a/example/lib/pages/lookup_address_widget.dart
+++ b/example/lib/pages/lookup_address_widget.dart
@@ -10,39 +10,57 @@ class _LookupAddressState extends State<LookupAddressWidget> {
   final Geolocator _geolocator = Geolocator();
   final TextEditingController _addressTextController = TextEditingController();
 
-  String _placemarkCoords = '';
+  List<String> _placemarkCoords = [];
 
-  Future<void> _onLookupCoordinatesPressed() async {
-    final List<Placemark> placemarks =
-        await _geolocator.placemarkFromAddress(_addressTextController.text);
+  Future<void> _onLookupCoordinatesPressed(BuildContext context) async {
+    final List<Placemark> placemarks = await Future(
+            () => _geolocator.placemarkFromAddress(_addressTextController.text))
+        .catchError((onError) {
+      Scaffold.of(context).showSnackBar(SnackBar(
+        content: Text(onError.toString()),
+      ));
+      return Future.value(List<Placemark>());
+    });
 
     if (placemarks != null && placemarks.isNotEmpty) {
       final Placemark pos = placemarks[0];
+      final List<String> coords = placemarks
+          .map((placemark) =>
+              pos.position.latitude.toString() +
+              ', ' +
+              pos.position.longitude.toString())
+          .toList();
       setState(() {
-        _placemarkCoords = pos.position.latitude.toString() +
-            ', ' +
-            pos.position.longitude.toString();
+        _placemarkCoords = coords;
       });
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        TextField(
-          decoration:
-              const InputDecoration(hintText: 'Please enter an address'),
-          controller: _addressTextController,
-        ),
-        RaisedButton(
-          child: const Text('Look up...'),
-          onPressed: () {
-            _onLookupCoordinatesPressed();
-          },
-        ),
-        Text(_placemarkCoords),
-      ],
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        children: <Widget>[
+          TextField(
+            decoration:
+                const InputDecoration(hintText: 'Please enter an address'),
+            controller: _addressTextController,
+          ),
+          RaisedButton(
+            child: const Text('Look up...'),
+            onPressed: () {
+              _onLookupCoordinatesPressed(context);
+            },
+          ),
+          Flexible(
+            child: ListView.builder(
+              itemCount: _placemarkCoords.length,
+              itemBuilder: (context, index) => Text(_placemarkCoords[index]),
+            ),
+          )
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- Show Geocoder example again
- Refactor tabs logic to handle conditional Android tab (`singleFusedLocation`) in single place.

### :arrow_heading_down: What is the current behavior?

Geocoder example is not accessable

### :new: What is the new behavior (if this is a feature change)?

Showing Geocoder example as tab

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing

Tabs might not fit on narrow screens? Didn't checked that... If that is the case maybe need to reconsider tab usage. Replace with simple list of button?

### :memo: Links to relevant issues/docs

refs #293

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop