### PR TITLE
Change geocoding results limit for Android

### DIFF
--- a/android/src/main/java/com/baseflow/geolocator/tasks/ForwardGeocodingTask.java
+++ b/android/src/main/java/com/baseflow/geolocator/tasks/ForwardGeocodingTask.java
@@ -41,7 +41,7 @@ class ForwardGeocodingTask extends Task<ForwardGeocodingOptions> {
       @Override
       public void run() {
         try {
-          List<Address> addresses = geocoder.getFromLocationName(options.getAddressToLookup(), 1);
+          List<Address> addresses = geocoder.getFromLocationName(options.getAddressToLookup(), 5);
 
           if (addresses.size() > 0) {
             MainThreadDispatcher.dispatchSuccess(


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Increase Geocoder limit from 1 to 5 for Android. However Android still returns [0, 1] results from my testing. But in case API miraculously finds more result then it would work in same was as iOS does.

### :arrow_heading_down: What is the current behavior?

limited to 1

### :new: What is the new behavior (if this is a feature change)?

limited to 5

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#293

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop