### PR TITLE
Make sure heading is returned on iOS

### DIFF
--- a/ios/Classes/Extensions/CLLocation_Extensions.m
+++ b/ios/Classes/Extensions/CLLocation_Extensions.m
@@ -16,7 +16,7 @@
              @"altitude": @(self.altitude),
              @"accuracy": @(self.horizontalAccuracy),
              @"speed": @(self.speed),
-             @"speed_accuracy": @0.0,
+             @"speed_accuracy": @(self.course),
              };
 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behaviour?

On iOS the value of the `heading` property on the `Position` class is always 0.0

### :new: What is the new behaviour (if this is a feature change)?

When the heading is available it is now returned as part of the `heading` property on the `Position` class.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Fetch a location

### :memo: Links to relevant issues/docs

- Fixes #142
- Fixes #331

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop