### PR TITLE
Downgrade meta package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.1.4+1]
+
+* Downgrade the "meta" package to version 1.7.0 since pub.dev static code analysis reports errors.
+
 ## [5.1.4]
 
 * Added support for Android 10’s background location permission;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use this plugin, add `geolocator` as a [dependency in your pubspec.yaml file]
 
 ```yaml
 dependencies:
-  geolocator: ^5.1.3
+  geolocator: ^5.1.4+1
 ```
 
 Paul Halliday wrote a nice introductory article on [getting the user's location using the Geolocator plugin](https://alligator.io/flutter/geolocator-plugin/). If you are new to the plugin this would be a great place to get started. 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geolocator
 description: Geolocation plugin for Flutter. This plugin provides a cross-platform (iOS, Android) API for generic location (GPS etc.) functions.
-version: 5.1.4
+version: 5.1.4+1
 author: Baseflow <hello@baseflow.com>
 homepage: https://github.com/baseflowit/flutter-geolocator
 
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  meta: ^1.1.7
+  meta: ^1.1.6
 
   google_api_availability: ^2.0.1
   location_permissions: ^2.0.3
@@ -21,7 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter  
 
-  pedantic: ^1.8.0+1
+  pedantic: ^1.7.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

The update of the meta package in previous version is causing errors in Pub.dev (they haven't upgraded yet to latest Flutter version);

### :new: What is the new behavior (if this is a feature change)?

Downgrade to 1.1.7 version of the meta plugin.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Compile and run example app

### :memo: Links to relevant issues/docs

- Fixes #335 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [X] Relevant documentation was updated
- [X] Rebased onto current develop