### PR TITLE
Fix crashing bugs with JSON serialization

### DIFF
--- a/lib/models/placemark.dart
+++ b/lib/models/placemark.dart
@@ -90,7 +90,9 @@ class Placemark {
       subLocality: placemarkMap['subLocality'] ?? '',
       thoroughfare: placemarkMap['thoroughfare'] ?? '',
       subThoroughfare: placemarkMap['subThoroughfare'] ?? '',
-      position: Position.fromMap(placemarkMap['location']),
+      position: placemarkMap['position'] != null
+          ? Position.fromMap(placemarkMap['position'])
+          : null,
     );
   }
 

--- a/lib/models/position.dart
+++ b/lib/models/position.dart
@@ -118,7 +118,7 @@ class Position {
   Map<String, dynamic> toJson() => {
         'longitude': longitude,
         'latitude': latitude,
-        'timestamp': timestamp.millisecondsSinceEpoch,
+        'timestamp': timestamp?.millisecondsSinceEpoch,
         'mocked': mocked,
         'accuracy': accuracy,
         'altitude': altitude,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fixes

### :arrow_heading_down: What is the current behavior?
JSON error thrown during `jsonEncode(placemark)` if `placemark.position.timestamp == null`.
`ArgumentError` thrown during `Placemark.fromMap(placemark_map)` where `placemark_map` was created using `jsonEncode(placemark)`.

### :new: What is the new behavior (if this is a feature change)?
No errors in the above cases. Proper deserialization of `Placemark` from map whether or not `position` is supplied.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Using a `Placemark` without a `timestamp`, e.g. by using Android 10 in an emulator, call `Placemark.fromMap(jsonEncode(placemark))`

### :memo: Links to relevant issues/docs
n/a

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [-] Relevant documentation was updated
- [X] Rebased onto current develop